### PR TITLE
Support single-image evaluation (GQA) alongside image-pair tasks (NLVR2) 

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""
+Comprehensive PROVE evaluation with dual-model scoring.
+
+Runs the new pipeline on NLVR2 balanced test set, collecting BOTH
+BLIP-ITM and Qwen logit-based scores for every verification action.
+Saves all intermediate data for post-hoc experiments.
+"""
+
+import os
+import sys
+import json
+import gc
+import time
+import argparse
+import traceback
+import torch
+from pathlib import Path
+from PIL import Image
+from tqdm import tqdm
+
+sys.path.insert(0, '/home/huan2073/PROVE')
+
+from src.core.model_manager import ModelManager
+from src.core.knowledge_base import KnowledgeBase
+from src.pipeline.detector import Detector
+from src.pipeline.unified_agent import UnifiedAgent, EvidenceCollection, EntityCandidate
+from src.pipeline.problog_executor import ProbLogExecutor
+from src.pipeline.problog_builder import ProbLogFactBuilder
+from src.vision.qwen_verifier import QwenVerifier
+from src.vision.blip_verifier import BLIPVerifier
+
+
+def identifier_to_image_paths(identifier, img_dir, directory=None):
+    """Map NLVR2 identifier to image file paths.
+
+    identifier format: "test1-X-Y-Z" → images "test1-X-Y-img0.png" and "test1-X-Y-img1.png"
+    Also checks nested train directory structure: images/train/{directory}/train-X-Y-img0.png
+    """
+    parts = identifier.rsplit("-", 1)
+    img_base = parts[0]
+    img_a = os.path.join(img_dir, f"{img_base}-img0.png")
+    img_b = os.path.join(img_dir, f"{img_base}-img1.png")
+
+    # If flat paths don't exist, check nested directory structure (train data)
+    if not os.path.exists(img_a) and directory is not None:
+        split = identifier.split("-")[0]  # "train", "test1", "dev"
+        nested_a = os.path.join(img_dir, "images", split, str(directory), f"{img_base}-img0.png")
+        nested_b = os.path.join(img_dir, "images", split, str(directory), f"{img_base}-img1.png")
+        if os.path.exists(nested_a):
+            return nested_a, nested_b
+
+    return img_a, img_b
+
+
+def load_gqa_samples(json_path, img_dir):
+    """Load GQA dataset samples.
+
+    GQA format: dict of {question_id: {question, imageId, answer, ...}}
+    Returns list of dicts with unified keys matching NLVR2 format.
+    """
+    with open(json_path) as f:
+        data = json.load(f)
+
+    samples = []
+    for qid, entry in data.items():
+        image_id = entry["imageId"]
+        answer = entry["answer"].lower()
+        # Map yes/no to True/False for consistency with NLVR2
+        label = answer == "yes"
+
+        # Try .jpg first, then .png
+        img_path = os.path.join(img_dir, f"{image_id}.jpg")
+        if not os.path.exists(img_path):
+            img_path = os.path.join(img_dir, f"{image_id}.png")
+
+        samples.append({
+            "identifier": qid,
+            "sentence": entry["question"],
+            "label": label,
+            "image_path": img_path,
+            "gqa_answer": answer,
+        })
+
+    return samples
+
+
+def rescore_with_qwen(evidence, candidates, image_paths, qwen_yn, qwen_tf):
+    """Re-score all attribute and relationship evidence with Qwen verifiers.
+
+    Returns dicts mapping (entity_id, attribute, value) → scores for attrs,
+    and (subject_id, object_id, relation) → scores for rels.
+    """
+    attr_scores = []
+    rel_scores = []
+
+    # Re-score attributes
+    # New pipeline: 3-tuple (entity_id, attribute_value, probability)
+    for entity_id, attr_value, blip_score in evidence.attributes:
+        # Find entity bbox
+        entity = None
+        for c in candidates:
+            if c.entity_id == entity_id:
+                entity = c
+                break
+
+        if entity is None:
+            attr_scores.append({
+                "entity_id": entity_id, "value": attr_value,
+                "blip_score": blip_score,
+                "image_id": None, "bbox": None, "object_class": None,
+                "qwen_yn_score": None, "qwen_yn_response": None,
+                "qwen_tf_score": None, "qwen_tf_response": None,
+            })
+            continue
+
+        image_path = image_paths.get(entity.image_id)
+        if not image_path or not os.path.exists(image_path):
+            attr_scores.append({
+                "entity_id": entity_id, "value": attr_value,
+                "blip_score": blip_score,
+                "image_id": entity.image_id, "bbox": entity.bbox,
+                "object_class": entity.object_class,
+                "qwen_yn_score": None, "qwen_yn_response": None,
+                "qwen_tf_score": None, "qwen_tf_response": None,
+            })
+            continue
+
+        try:
+            yn_score, yn_resp = qwen_yn.verify_attribute(
+                image_path, entity.bbox, entity.object_class, attr_value, use_logits=True
+            )
+            tf_score, tf_resp = qwen_tf.verify_attribute(
+                image_path, entity.bbox, entity.object_class, attr_value, use_logits=True
+            )
+        except Exception as e:
+            yn_score, yn_resp = None, f"ERROR: {e}"
+            tf_score, tf_resp = None, f"ERROR: {e}"
+
+        attr_scores.append({
+            "entity_id": entity_id, "value": attr_value,
+            "blip_score": blip_score,
+            "image_id": entity.image_id, "bbox": entity.bbox,
+            "object_class": entity.object_class,
+            "qwen_yn_score": yn_score, "qwen_yn_response": yn_resp,
+            "qwen_tf_score": tf_score, "qwen_tf_response": tf_resp,
+        })
+
+    # Re-score relationships
+    for subject_id, object_id, relation, blip_score in evidence.relationships:
+        subject = None
+        obj = None
+        for c in candidates:
+            if c.entity_id == subject_id:
+                subject = c
+            if c.entity_id == object_id:
+                obj = c
+
+        if subject is None or obj is None:
+            rel_scores.append({
+                "subject_id": subject_id, "object_id": object_id, "relation": relation,
+                "blip_score": blip_score,
+                "image_id": None, "bbox1": None, "bbox2": None,
+                "obj1_class": None, "obj2_class": None,
+                "qwen_yn_score": None, "qwen_yn_response": None,
+                "qwen_tf_score": None, "qwen_tf_response": None,
+            })
+            continue
+
+        image_path = image_paths.get(subject.image_id)
+        if not image_path or not os.path.exists(image_path):
+            rel_scores.append({
+                "subject_id": subject_id, "object_id": object_id, "relation": relation,
+                "blip_score": blip_score,
+                "image_id": subject.image_id,
+                "bbox1": subject.bbox, "bbox2": obj.bbox,
+                "obj1_class": subject.object_class, "obj2_class": obj.object_class,
+                "qwen_yn_score": None, "qwen_yn_response": None,
+                "qwen_tf_score": None, "qwen_tf_response": None,
+            })
+            continue
+
+        try:
+            yn_score, yn_resp = qwen_yn.verify_relationship(
+                image_path, subject.bbox, obj.bbox,
+                subject.object_class, obj.object_class, relation, use_logits=True
+            )
+            tf_score, tf_resp = qwen_tf.verify_relationship(
+                image_path, subject.bbox, obj.bbox,
+                subject.object_class, obj.object_class, relation, use_logits=True
+            )
+        except Exception as e:
+            yn_score, yn_resp = None, f"ERROR: {e}"
+            tf_score, tf_resp = None, f"ERROR: {e}"
+
+        rel_scores.append({
+            "subject_id": subject_id, "object_id": object_id, "relation": relation,
+            "blip_score": blip_score,
+            "image_id": subject.image_id,
+            "bbox1": subject.bbox, "bbox2": obj.bbox,
+            "obj1_class": subject.object_class, "obj2_class": obj.object_class,
+            "qwen_yn_score": yn_score, "qwen_yn_response": yn_resp,
+            "qwen_tf_score": tf_score, "qwen_tf_response": tf_resp,
+        })
+
+    # Count evidence (no alternative scoring — based on detection confidence)
+    count_data = []
+    for ce in evidence.counts:
+        count_data.append({
+            "query_type": ce.query_type,
+            "object_class": ce.object_class,
+            "probability": ce.probability,
+            "image_id": ce.image_id,
+            "image_id_a": ce.image_id_a,
+            "image_id_b": ce.image_id_b,
+            "value": ce.value,
+        })
+
+    return attr_scores, rel_scores, count_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PROVE evaluation with dual scoring")
+    parser.add_argument("--dataset", choices=["nlvr2", "gqa"], default="nlvr2",
+                        help="Dataset type: nlvr2 (image pairs) or gqa (single image)")
+    parser.add_argument("--test_json",
+                        default=None,
+                        help="Path to test data (default depends on --dataset)")
+    parser.add_argument("--img_dir",
+                        default=None,
+                        help="Path to images directory (default depends on --dataset)")
+    parser.add_argument("--output_dir",
+                        default="/home/huan2073/PROVE/eval/dual_eval")
+    parser.add_argument("--max_samples", type=int, default=0,
+                        help="Max samples to process (0 = all)")
+    parser.add_argument("--resume_from", type=int, default=0,
+                        help="Resume from this sample index")
+    parser.add_argument("--end_at", type=int, default=0,
+                        help="Stop at this sample index (0 = process all)")
+    parser.add_argument("--z_filter", type=int, default=None, choices=[0, 1],
+                        help="Only keep samples with this Z value (0 or 1) to avoid duplicates (NLVR2 only)")
+    parser.add_argument("--thinking_budget", type=int, default=None,
+                        help="Enable Claude extended thinking with this token budget (e.g. 4096)")
+    parser.add_argument("--cot", action="store_true",
+                        help="Enable prompt-level chain-of-thought reasoning")
+    parser.add_argument("--blip_lora_path", type=str, default=None,
+                        help="Path to fine-tuned BLIP LoRA adapter (e.g. eval/vqa_finetune/blip_lora_best)")
+    parser.add_argument("--retry_failed", action="store_true",
+                        help="Remove failed entries from results and retry them")
+    args = parser.parse_args()
+
+    # Set dataset-specific defaults
+    if args.dataset == "gqa":
+        if args.test_json is None:
+            args.test_json = "/scratch/gautschi/huan2073/gqa_data/testdev_balanced_yn.json"
+        if args.img_dir is None:
+            args.img_dir = "/scratch/gautschi/huan2073/gqa_data/images"
+    else:
+        if args.test_json is None:
+            args.test_json = "/scratch/gautschi/huan2073/nlvr2_data/balanced_test1.json"
+        if args.img_dir is None:
+            args.img_dir = "/scratch/gautschi/huan2073/nlvr2_data/images"
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Load test data
+    is_gqa = args.dataset == "gqa"
+    print(f"Loading test data ({args.dataset})...")
+
+    if is_gqa:
+        samples = load_gqa_samples(args.test_json, args.img_dir)
+    else:
+        # NLVR2: JSONL format
+        samples = []
+        with open(args.test_json) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    samples.append(json.loads(line))
+
+        # Filter by Z value to avoid duplicate image pairs
+        if args.z_filter is not None:
+            before = len(samples)
+            samples = [s for s in samples if s['identifier'].endswith(f'-{args.z_filter}')]
+            print(f"Filtered Z={args.z_filter}: {before} → {len(samples)} samples")
+
+    # Pre-filter to samples with valid images, then apply max_samples
+    if args.max_samples > 0:
+        valid_samples = []
+        skipped = 0
+        for s in samples:
+            if is_gqa:
+                valid = os.path.exists(s["image_path"])
+            else:
+                img_a, img_b = identifier_to_image_paths(
+                    s["identifier"], args.img_dir, directory=s.get("directory"))
+                valid = os.path.exists(img_a) and os.path.exists(img_b)
+            if valid:
+                valid_samples.append(s)
+                if len(valid_samples) >= args.max_samples:
+                    break
+            else:
+                skipped += 1
+        print(f"Skipped {skipped} samples with missing images")
+        samples = valid_samples
+    print(f"Loaded {len(samples)} samples")
+
+    # Initialize models
+    print("Initializing models...")
+    mm = ModelManager()
+
+    # Pre-initialize LLM client with model ID and thinking/CoT settings
+    # (singleton ensures all pipeline components use the same instance)
+    from src.language.llm_client import LLMClient
+    model_id = os.getenv("LLAMA33_MODEL_ID")
+    if args.thinking_budget or args.cot or model_id:
+        if args.thinking_budget:
+            print(f"Enabling extended thinking with budget={args.thinking_budget} tokens")
+        if args.cot:
+            print(f"Enabling prompt-level chain-of-thought")
+        print(f"Model ID: {model_id}")
+        mm._models['llm_client'] = LLMClient(
+            model_id=model_id,
+            thinking_budget=args.thinking_budget,
+            cot_enabled=args.cot
+        )
+
+    # Load fine-tuned BLIP if LoRA path provided
+    if args.blip_lora_path:
+        print(f"Using fine-tuned BLIP from {args.blip_lora_path}")
+        mm._models['blip_verifier'] = BLIPVerifier(device="auto", lora_path=args.blip_lora_path)
+
+    detector = Detector()
+    agent = UnifiedAgent(max_iterations=20)
+    executor = ProbLogExecutor()
+    fact_builder = ProbLogFactBuilder()
+
+    # Initialize Qwen verifiers (share underlying QwenVL model)
+    qwen_vl = mm.get_qwen_vl()
+    qwen_yn = QwenVerifier(qwen_vl=qwen_vl, prompt_style="yes_no")
+    qwen_tf = QwenVerifier(qwen_vl=qwen_vl, prompt_style="true_false")
+
+    print("All models loaded.\n")
+
+    # Process samples
+    results_file = os.path.join(args.output_dir, "all_results.json")
+
+    # Always load existing results to support preemption recovery
+    all_results = []
+    done_identifiers = set()
+    if os.path.exists(results_file):
+        try:
+            with open(results_file) as f:
+                all_results = json.load(f)
+            if args.retry_failed:
+                # Only skip successful samples — retry failed ones
+                failed_ids = {r.get('identifier') for r in all_results if not r.get('success') and r.get('identifier')}
+                all_results = [r for r in all_results if r.get('success')]
+                done_identifiers = {r.get('identifier') for r in all_results if r.get('identifier')}
+                print(f"Loaded {len(all_results)} successful results, removed {len(failed_ids)} failed for retry")
+            else:
+                done_identifiers = {r.get('identifier') for r in all_results if r.get('identifier')}
+                print(f"Loaded {len(all_results)} existing results from {results_file} "
+                      f"({len(done_identifiers)} unique identifiers)")
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Warning: could not load existing results: {e}")
+            all_results = []
+
+    n_success = sum(1 for r in all_results if r.get("success"))
+    n_fail = sum(1 for r in all_results if not r.get("success"))
+    start_time = time.time()
+
+    for idx, sample in enumerate(tqdm(samples, desc="Evaluating")):
+        if idx < args.resume_from:
+            continue
+        if args.end_at > 0 and idx >= args.end_at:
+            break
+
+        identifier = sample["identifier"]
+
+        # Skip already-processed samples (preemption recovery)
+        if identifier in done_identifiers:
+            continue
+        sentence = sample["sentence"]
+        label_str = sample.get("label", "False")
+        label = label_str if isinstance(label_str, bool) else label_str.lower() == "true"
+
+        # Build image_paths dict based on dataset type
+        if is_gqa:
+            img_path = sample["image_path"]
+            image_paths = {"image_a": img_path}
+            missing_images = not os.path.exists(img_path)
+        else:
+            img_a_path, img_b_path = identifier_to_image_paths(
+                identifier, args.img_dir, directory=sample.get("directory"))
+            image_paths = {"image_a": img_a_path, "image_b": img_b_path}
+            missing_images = not os.path.exists(img_a_path) or not os.path.exists(img_b_path)
+
+        result = {
+            "identifier": identifier,
+            "sentence": sentence,
+            "label": label,
+            "success": False,
+        }
+
+        if missing_images:
+            result["error"] = "Image files not found"
+            all_results.append(result)
+            n_fail += 1
+            continue
+
+        try:
+
+            # Step 1: Detection
+            kb = KnowledgeBase(ultimate_question=sentence)
+            for image_id, image_path in image_paths.items():
+                detections = detector.detect_from_question(image_path, sentence)
+                kb.add_objects(image_id, detections)
+
+            # Save detection info
+            det_info = {}
+            for image_id, image_data in kb.images.items():
+                det_info[image_id] = [
+                    {"label": obj.label, "bbox": obj.bbox,
+                     "confidence": obj.confidence, "object_id": obj.object_id}
+                    for obj in image_data.objects
+                ]
+            result["detections"] = det_info
+
+            # Step 2: Evidence collection (uses BLIP for verification)
+            evidence = agent.collect_evidence(
+                question=sentence,
+                images=kb.images,
+                image_paths=image_paths
+            )
+
+            # Build candidates list for Qwen re-scoring
+            candidates = []
+            for image_id, image_data in kb.images.items():
+                letter = image_id.replace("image_", "")
+                for obj in image_data.objects:
+                    candidates.append(EntityCandidate(
+                        entity_id=f"{obj.label}_{letter}_{obj.object_id}",
+                        image_id=image_id,
+                        object_class=obj.label,
+                        bbox=obj.bbox,
+                        confidence=obj.confidence
+                    ))
+
+            # Step 3: Re-score with Qwen
+            attr_scores, rel_scores, count_data = rescore_with_qwen(
+                evidence, candidates, image_paths, qwen_yn, qwen_tf
+            )
+
+            result["evidence"] = {
+                "attributes": attr_scores,
+                "relationships": rel_scores,
+                "counts": count_data,
+                "action_history": evidence.action_history,
+            }
+
+            # Step 4: ProbLog execution
+            prob_facts = fact_builder.build_facts(evidence, kb.images)
+
+            # Save facts for post-hoc re-execution
+            facts_data = [
+                {"predicate": f.predicate, "arguments": f.arguments,
+                 "probability": f.probability}
+                for f in prob_facts
+            ]
+
+            # Run ProbLog with BLIP scores (default)
+            prob_result, det_result = executor.execute_dual(
+                question=sentence,
+                evidence=evidence,
+                images=kb.images,
+                threshold=0.5
+            )
+
+            result["problog"] = {
+                "rules": "",  # Will be filled from problog_program
+                "query": "",
+                "facts": facts_data,
+            }
+
+            # Extract rules and query from problog program
+            program = prob_result.problog_program
+            if program:
+                # Parse rules and query from the program string
+                lines = program.split("\n")
+                rule_lines = []
+                query_lines = []
+                for line in lines:
+                    stripped = line.strip()
+                    if stripped.startswith("query("):
+                        query_lines.append(stripped)
+                    elif stripped and not stripped.startswith("%") and "::" not in stripped:
+                        rule_lines.append(stripped)
+                result["problog"]["rules"] = "\n".join(rule_lines)
+                result["problog"]["query"] = "\n".join(query_lines)
+
+            result["results"] = {
+                "prove_answer": prob_result.final_answer,
+                "deprove_answer": det_result.final_answer,
+                "prove_prob": prob_result.probability,
+                "deprove_prob": det_result.probability,
+                "prove_program": prob_result.problog_program,
+                "deprove_program": det_result.problog_program,
+            }
+
+            result["success"] = True
+            n_success += 1
+
+        except Exception as e:
+            result["error"] = str(e)
+            result["traceback"] = traceback.format_exc()
+            n_fail += 1
+            print(f"  FAILED: {identifier}: {e}")
+
+        all_results.append(result)
+
+        # Periodic save and cleanup
+        if (idx + 1) % 25 == 0:
+            with open(results_file, "w") as f:
+                json.dump(all_results, f, indent=2)
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+            elapsed = time.time() - start_time
+            rate = (idx + 1 - args.resume_from) / elapsed * 3600
+            print(f"\n  Progress: {idx+1}/{len(samples)}, "
+                  f"success={n_success}, fail={n_fail}, "
+                  f"rate={rate:.0f}/hr, "
+                  f"elapsed={elapsed/60:.1f}min")
+
+    # Final save
+    with open(results_file, "w") as f:
+        json.dump(all_results, f, indent=2)
+
+    # Print summary
+    elapsed = time.time() - start_time
+    print(f"\n{'='*60}")
+    print(f"EVALUATION COMPLETE")
+    print(f"{'='*60}")
+    print(f"Total: {len(all_results)}, Success: {n_success}, Failed: {n_fail}")
+    print(f"Time: {elapsed/60:.1f} minutes ({elapsed/3600:.1f} hours)")
+
+    # Quick accuracy check
+    successful = [r for r in all_results if r.get("success")]
+    if successful:
+        prove_correct = sum(1 for r in successful
+                           if (r["results"]["prove_answer"] == "True") == r["label"])
+        deprove_correct = sum(1 for r in successful
+                             if (r["results"]["deprove_answer"] == "True") == r["label"])
+        total = len(successful)
+        print(f"\nPROVE accuracy:   {prove_correct}/{total} = {prove_correct/total*100:.1f}%")
+        print(f"DePROVE accuracy: {deprove_correct}/{total} = {deprove_correct/total*100:.1f}%")
+
+        # McNemar's test
+        pw = sum(1 for r in successful
+                 if (r["results"]["prove_answer"] == "True") == r["label"]
+                 and (r["results"]["deprove_answer"] == "True") != r["label"])
+        dw = sum(1 for r in successful
+                 if (r["results"]["deprove_answer"] == "True") == r["label"]
+                 and (r["results"]["prove_answer"] == "True") != r["label"])
+        chi2 = (abs(pw - dw) - 1)**2 / (pw + dw) if (pw + dw) > 0 else 0
+        sig = "***" if chi2 > 3.84 and pw > dw else ""
+        print(f"McNemar: PW={pw}, DW={dw}, chi²={chi2:.2f} {sig}")
+
+    print(f"\nResults saved to {results_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/language/output_models.py
+++ b/src/language/output_models.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
+import re
 from typing import List, Dict, Literal, Union
 from pydantic import BaseModel, Field, field_validator
+
+
+def _validate_image_id(v: str) -> str:
+    """Validate that image_id matches the pattern 'image_X' where X is a lowercase letter."""
+    if not re.match(r'^image_[a-z]$', v):
+        raise ValueError(f"image_id must match 'image_X' pattern (e.g. 'image_a'), got '{v}'")
+    return v
 
 
 class EntityExtractionResponse(BaseModel):
@@ -54,9 +62,7 @@ class PerceiveAction(BaseModel):
     @field_validator('image_id')
     @classmethod
     def validate_image_id(cls, v):
-        if v not in ['image_a', 'image_b']:
-            raise ValueError("image_id must be 'image_a' or 'image_b'")
-        return v
+        return _validate_image_id(v)
 
 
 class VerifyAttributeAction(BaseModel):
@@ -79,9 +85,7 @@ class VerifyAttributeAction(BaseModel):
     @field_validator('image_id')
     @classmethod
     def validate_image_id(cls, v):
-        if v not in ['image_a', 'image_b']:
-            raise ValueError("image_id must be 'image_a' or 'image_b'")
-        return v
+        return _validate_image_id(v)
 
 
 class VerifyRelationshipAction(BaseModel):
@@ -105,9 +109,7 @@ class VerifyRelationshipAction(BaseModel):
     @field_validator('image_id')
     @classmethod
     def validate_image_id(cls, v):
-        if v not in ['image_a', 'image_b']:
-            raise ValueError("image_id must be 'image_a' or 'image_b'")
-        return v
+        return _validate_image_id(v)
 
 
 class VerifyCountAction(BaseModel):
@@ -142,8 +144,8 @@ class VerifyCountAction(BaseModel):
     @field_validator('image_id', 'image_id_a', 'image_id_b')
     @classmethod
     def validate_image_id(cls, v):
-        if v is not None and v not in ['image_a', 'image_b']:
-            raise ValueError("image_id must be 'image_a' or 'image_b'")
+        if v is not None:
+            return _validate_image_id(v)
         return v
 
 

--- a/src/pipeline/problog_executor.py
+++ b/src/pipeline/problog_executor.py
@@ -98,8 +98,16 @@ class ProbLogExecutor:
 
         Dynamically detects which count predicates appear in the facts
         and only advertises those, preventing the LLM from inventing
-        predicates that don't exist.
+        predicates that don't exist. Also adapts examples based on
+        how many images are present in the facts.
         """
+        # Detect which image IDs appear in the facts
+        import re
+        image_ids = sorted(set(re.findall(r'image_[a-z]', facts_str)))
+        if not image_ids:
+            image_ids = ['image_a']  # fallback
+        multi_image = len(image_ids) > 1
+
         # Detect which count predicates actually appear in the facts
         count_pred_descriptions = {
             'count_at_least': 'count_at_least(image_id, class, N) - at least N objects in image',
@@ -151,6 +159,87 @@ class ProbLogExecutor:
             if missing_preds:
                 predicate_section += f"\n\nWARNING: The following predicates are NOT available in the facts: {', '.join(missing_preds)}. Do NOT use them."
 
+        # Build answer pattern guidance based on image count
+        if multi_image:
+            answer_pattern = "- ANSWER PATTERN: Always define an `answer` rule and end with `query(answer).`. For per-image conditions, write helper rule(s) with variable I, then combine in `answer :- ...`. For cross-image count predicates (count_total_*, count_more, count_fewer, count_equal), use them DIRECTLY in the answer rule — they already span both images. Never generate more than one query statement."
+            connectives = """- LOGICAL CONNECTIVES: Choose connectives based on the question's logical meaning:
+  - `,` (AND/conjunction): ALL conditions must hold. Use when the question requires EVERY image to satisfy the condition (e.g., "all images show X", "both images have X", "each image contains X").
+  - `;` (OR/disjunction): AT LEAST ONE condition must hold. Use when the question requires ANY image to satisfy the condition (e.g., "at least one X is Y", "there is an X that is Y", "either image shows X").
+  - Parenthesized mix: Use `(cond_a ; cond_b)` within a larger conjunction when part of the question is universal and part is existential (e.g., "same count AND at least one does X").
+  Analyze what the question actually requires — do not default to AND or OR without reasoning about the meaning."""
+        else:
+            img = image_ids[0]
+            answer_pattern = f"- ANSWER PATTERN: Always define an `answer` rule and end with `query(answer).`. Write helper rule(s) with variable I, then use `answer :- helper({img}).`. Never generate more than one query statement."
+            connectives = """- LOGICAL CONNECTIVES: Use `,` (AND) to combine multiple conditions that must all hold. Use `;` (OR) when at least one condition suffices."""
+
+        # Build example patterns based on image count
+        img_a = image_ids[0]
+        if multi_image:
+            img_b = image_ids[1]
+            examples = f"""EXAMPLE PATTERNS:
+
+Single image condition:
+is_tall_building(I) :-
+    entity(I, E, building),
+    attribute(I, E, tall).
+answer :- is_tall_building({img_a}).
+query(answer).
+
+Both images must satisfy condition → AND (,):
+has_red_car(I) :-
+    entity(I, E, car),
+    attribute(I, E, red).
+answer :- has_red_car({img_a}), has_red_car({img_b}).
+query(answer).
+
+At least one image satisfies condition → OR (;):
+cat_on_table(I) :-
+    entity(I, E1, cat),
+    entity(I, E2, table),
+    relation(I, E1, E2, 'on top of').
+answer :- cat_on_table({img_a}) ; cat_on_table({img_b}).
+query(answer).
+
+Cross-image count (use directly, do NOT wrap in per-image helper):
+answer :- count_total_at_most({img_a}, {img_b}, dog, 3).
+query(answer).
+
+Mixed per-image + cross-image count:
+dog_sitting(I) :-
+    entity(I, E1, dog),
+    entity(I, E2, couch),
+    relation(I, E1, E2, on).
+answer :-
+    count_equal({img_a}, {img_b}, dog),
+    (dog_sitting({img_a}) ; dog_sitting({img_b})).
+query(answer)."""
+        else:
+            examples = f"""EXAMPLE PATTERNS:
+
+Simple attribute check:
+is_tall_building(I) :-
+    entity(I, E, building),
+    attribute(I, E, tall).
+answer :- is_tall_building({img_a}).
+query(answer).
+
+Relationship check:
+cat_on_table(I) :-
+    entity(I, E1, cat),
+    entity(I, E2, table),
+    relation(I, E1, E2, 'on top of').
+answer :- cat_on_table({img_a}).
+query(answer).
+
+Multiple conditions:
+wet_surfer_with_wetsuit(I) :-
+    entity(I, E1, surfer),
+    attribute(I, E1, wet),
+    entity(I, E2, wetsuit),
+    relation(I, E1, E2, wearing).
+answer :- wet_surfer_with_wetsuit({img_a}).
+query(answer)."""
+
         prompt = f"""Generate ProbLog rules and query to answer this question.
 
 {predicate_section}
@@ -164,12 +253,8 @@ IMPORTANT RULES:
 - SELECTIVE USAGE: You do NOT need to use all facts. Only use facts relevant to answering the question.
 - INCOMPLETE EVIDENCE: If the evidence is incomplete, write rules using only the facts that ARE available. Do not reference facts that do not exist.
 - PURE LOGIC ONLY: Do NOT embed numeric literals, probability values, or arithmetic comparisons (like 0.8, <=, >=) in rule bodies. ProbLog rules must contain only predicate calls and logical connectives (, ; \\+). Probabilities are handled by the facts, not the rules.
-- ANSWER PATTERN: Always define an `answer` rule and end with `query(answer).`. For per-image conditions, write helper rule(s) with variable I, then combine in `answer :- ...`. For cross-image count predicates (count_total_*, count_more, count_fewer, count_equal), use them DIRECTLY in the answer rule — they already span both images. Never generate more than one query statement.
-- LOGICAL CONNECTIVES: Choose connectives based on the question's logical meaning:
-  - `,` (AND/conjunction): ALL conditions must hold. Use when the question requires EVERY image to satisfy the condition (e.g., "all images show X", "both images have X", "each image contains X").
-  - `;` (OR/disjunction): AT LEAST ONE condition must hold. Use when the question requires ANY image to satisfy the condition (e.g., "at least one X is Y", "there is an X that is Y", "either image shows X").
-  - Parenthesized mix: Use `(cond_a ; cond_b)` within a larger conjunction when part of the question is universal and part is existential (e.g., "same count AND at least one does X").
-  Analyze what the question actually requires — do not default to AND or OR without reasoning about the meaning.
+{answer_pattern}
+{connectives}
 
 QUESTION: {question}
 
@@ -178,43 +263,7 @@ Generate ONLY:
 2. An answer rule combining the conditions
 3. query(answer).
 
-EXAMPLE PATTERNS:
-
-Single image:
-is_tall_building(I) :-
-    entity(I, E, building),
-    attribute(I, E, tall).
-answer :- is_tall_building(image_a).
-query(answer).
-
-Both images must satisfy condition → AND (,):
-has_red_car(I) :-
-    entity(I, E, car),
-    attribute(I, E, red).
-answer :- has_red_car(image_a), has_red_car(image_b).
-query(answer).
-
-At least one image satisfies condition → OR (;):
-cat_on_table(I) :-
-    entity(I, E1, cat),
-    entity(I, E2, table),
-    relation(I, E1, E2, 'on top of').
-answer :- cat_on_table(image_a) ; cat_on_table(image_b).
-query(answer).
-
-Cross-image count (use directly, do NOT wrap in per-image helper):
-answer :- count_total_at_most(image_a, image_b, dog, 3).
-query(answer).
-
-Mixed per-image + cross-image count:
-dog_sitting(I) :-
-    entity(I, E1, dog),
-    entity(I, E2, couch),
-    relation(I, E1, E2, on).
-answer :-
-    count_equal(image_a, image_b, dog),
-    (dog_sitting(image_a) ; dog_sitting(image_b)).
-query(answer).
+{examples}
 
 Output rules and query only, no explanation:"""
         return prompt
@@ -241,13 +290,13 @@ Output rules and query only, no explanation:"""
             rules, query = self._parse_response(response)
 
             if not query.startswith("query("):
-                return self._fallback_query(question)
+                return self._fallback_query(question, facts)
 
             return rules, query
 
         except Exception as e:
             print(f"  Warning: Query generation failed: {e}")
-            return self._fallback_query(question)
+            return self._fallback_query(question, facts)
 
     def _parse_response(self, response: str) -> Tuple[str, str]:
         """Parse LLM response into rules and query."""
@@ -268,11 +317,26 @@ Output rules and query only, no explanation:"""
 
         return '\n'.join(rules_lines), '\n'.join(query_lines)
 
-    def _fallback_query(self, question: str) -> Tuple[str, str]:
+    def _fallback_query(self, question: str, facts: list = None) -> Tuple[str, str]:
         """Generate fallback query when LLM fails."""
-        # Extract image from question
-        match = re.search(r'image[_ ]([ab])', question.lower())
-        image_id = f"image_{match.group(1)}" if match else "image_a"
+        # Try to extract image from question
+        match = re.search(r'image[_ ]([a-z])', question.lower())
+        if match:
+            image_id = f"image_{match.group(1)}"
+        elif facts:
+            # Use first image_id found in facts
+            for f in facts:
+                for arg in f.arguments:
+                    if isinstance(arg, str) and arg.startswith('image_'):
+                        image_id = arg
+                        break
+                else:
+                    continue
+                break
+            else:
+                image_id = "image_a"
+        else:
+            image_id = "image_a"
 
         rules = "fallback(I) :- entity(I, _, _)."
         query = f"query(fallback({image_id}))."

--- a/src/pipeline/unified_agent.py
+++ b/src/pipeline/unified_agent.py
@@ -120,10 +120,13 @@ class UnifiedAgent:
         # Initialize evidence collection
         evidence = EvidenceCollection(question=question)
 
+        # Determine image IDs for prompt generation
+        image_ids = sorted(image_paths.keys())
+
         # ReAct loop
         for iteration in range(self.max_iterations):
             # Think: Get LLM decision on next action
-            action = self._get_llm_decision(question, candidates, evidence, iteration)
+            action = self._get_llm_decision(question, candidates, evidence, iteration, image_ids)
 
             if action is None:
                 break
@@ -174,133 +177,18 @@ class UnifiedAgent:
         question: str,
         candidates: List[EntityCandidate],
         evidence: EvidenceCollection,
-        iteration: int
+        iteration: int,
+        image_ids: List[str] = None
     ) -> Optional[AgentAction]:
         """Get next action from LLM using ReAct prompting with Pydantic validation."""
 
         llm_client = self.model_manager.get_llm_client()
 
-        system_prompt = """You are a ReAct evidence agent collecting evidence to answer a visual question about TWO images.
+        # Default to two-image setup for backward compatibility
+        if image_ids is None:
+            image_ids = ["image_a", "image_b"]
 
-IMAGES:
-- Image A, image_id: image_a (the question may refer to Image A as the left or the first image)
-- Image B, image_id: image_b (the question may refer to Image B as the right or the second image)
-
-GOAL:
-Collect all evidence required to answer the question. When done, the collected evidence alone should be sufficient to determine if the statement is true or false.
-
-EVIDENCE CHAINS:
-Questions often contain multiple connected claims. You must verify ALL parts of the chain.
-
-Common patterns:
-
-1. Count + Relationship: "At least one dog is sitting on the couch"
-   → Verify the count of dogs AND verify the "sitting on" relationship between dog and couch
-
-2. Count + Attribute: "There are two red cars"
-   → Verify the count of cars AND verify the "red" attribute for each car
-
-3. Attribute + Relationship: "The large cat is next to the bowl"
-   → Verify the "large" attribute for the cat AND verify the "next to" relationship between cat and bowl
-
-4. Multiple Attributes: "The car is red and shiny"
-   → Verify the "red" attribute AND verify the "shiny" attribute
-
-5. Count Comparison + Attribute: "There are more striped shirts in image A than B"
-   → Verify the count comparison between images AND verify the "striped" attribute for each of the shirts
-
-6. Relationship Chain: "The bird is on the branch which is above the water"
-   → Verify the "on" relationship between bird and branch AND verify the "above" relationship between branch and water
-
-Verifying only PART of a chain is INCOMPLETE - you must verify ALL parts.
-
-ACTIONS (output ONE as JSON):
-
-1. perceive - Ask open-ended question to gather information
-   Required fields: thought, action, image_id, question
-
-   Entity-level (also requires: entity_id):
-   - {"thought": "I need to know the dog's color", "action": "perceive", "image_id": "image_a", "entity_id": "dog_a_0", "question": "What color is this dog?"}
-
-   Image-level (no entity_id needed):
-   - {"thought": "I need to understand the scene", "action": "perceive", "image_id": "image_a", "question": "What is happening in this image?"}
-
-2. verify_attribute - Check if entity has specific attribute. Returns probability (0.0-1.0).
-   Required fields: thought, action, image_id, entity_id, attribute, verification
-   - attribute: the attribute being verified (e.g., "orange", "wooden", "showing teeth")
-   - verification: natural language describing the attribute (e.g., "an orange dog", "a dog showing its teeth")
-   Examples:
-   - {"thought": "Verifying the dog is orange", "action": "verify_attribute", "image_id": "image_a", "entity_id": "dog_a_0", "attribute": "orange", "verification": "an orange dog"}
-   - {"thought": "Verifying the dog is showing teeth", "action": "verify_attribute", "image_id": "image_b", "entity_id": "dog_b_2", "attribute": "showing teeth", "verification": "a dog showing its teeth"}
-
-3. verify_relationship - Check relationship between two entities in SAME image. Returns probability (0.0-1.0).
-   Supports both spatial relations (e.g., on, next to, left of, behind, above, etc.) and interactions (e.g., wearing, holding, eating, looking at, sitting on, etc.).
-   Required fields: thought, action, image_id, subject_id, object_id, relation, verification
-   - relation: the relationship being verified (e.g., "on top of", "wearing")
-   - verification: natural language describing the relationship (e.g., "a bird on top of a buffalo", "a man wearing a coat")
-   Examples:
-   - Spatial: {"thought": "Checking if bird is on buffalo", "action": "verify_relationship", "image_id": "image_a", "subject_id": "bird_a_0", "object_id": "buffalo_a_1", "relation": "on top of", "verification": "a bird on top of a buffalo"}
-   - Interaction: {"thought": "Checking if man is wearing coat", "action": "verify_relationship", "image_id": "image_a", "subject_id": "man_a_0", "object_id": "coat_a_1", "relation": "wearing", "verification": "a man wearing a coat"}
-
-4. verify_count - Verify count-related queries. Returns probability (0.0-1.0).
-   Required fields: thought, action, query_type, object_class
-
-   Single-image queries (also requires: image_id, value):
-   - "at_least": P(count >= N) - {"thought": "...", "action": "verify_count", "query_type": "at_least", "object_class": "dog", "image_id": "image_a", "value": 2}
-   - "at_most": P(count <= N) - {"thought": "...", "action": "verify_count", "query_type": "at_most", "object_class": "dog", "image_id": "image_a", "value": 2}
-   - "exactly": P(count == N) - {"thought": "...", "action": "verify_count", "query_type": "exactly", "object_class": "dog", "image_id": "image_a", "value": 2}
-
-   Cross-image comparison (also requires: image_id_a, image_id_b):
-   - "more": P(count_a > count_b) - {"thought": "...", "action": "verify_count", "query_type": "more", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b"}
-   - "fewer": P(count_a < count_b) - {"thought": "...", "action": "verify_count", "query_type": "fewer", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b"}
-   - "equal": P(count_a == count_b) - {"thought": "...", "action": "verify_count", "query_type": "equal", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b"}
-
-   Total across both images (also requires: image_id_a, image_id_b, value):
-   - "total_exactly": P(total == N) - {"thought": "...", "action": "verify_count", "query_type": "total_exactly", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b", "value": 5}
-   - "total_at_least": P(total >= N) - {"thought": "...", "action": "verify_count", "query_type": "total_at_least", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b", "value": 5}
-   - "total_at_most": P(total <= N) - {"thought": "...", "action": "verify_count", "query_type": "total_at_most", "object_class": "dog", "image_id_a": "image_a", "image_id_b": "image_b", "value": 5}
-
-5. done - Stop ONLY when ALL evidence has been collected
-   Required fields: thought, action
-   Example: {"thought": "I have verified ALL attributes, relationships, and counts mentioned in the question", "action": "done"}
-
-PERCEPTION SEMANTICS:
-- Perceive gathers contextual information to help you decide what to verify
-- Perceive does NOT collect probabilistic evidence - it only provides textual context
-- Image-level perceive: Use to understand the overall scene, context, or relationships in the whole image
-- Entity-level perceive: Use to gather specific information about a particular object
-- Use perceive to investigate, then verify to collect probabilistic evidence
-
-VERIFICATION SEMANTICS:
-- Verification returns a probability score (0.0-1.0) representing the model's confidence
-- This score is DETERMINISTIC - verifying the same thing again will return the same result
-- Low probability is valid evidence that something is likely FALSE
-- High probability is valid evidence that something is likely TRUE
-- Do NOT re-verify the same attribute or relationship - once you have the probability, that IS the evidence
-
-RULES:
-- COMPLETENESS IS REQUIRED: Verify ALL attributes, relationships, and counts in the question
-- Do NOT stop early - even if partial evidence seems sufficient to answer, you must verify everything
-- If the question mentions multiple entities/attributes, verify EACH ONE
-- Perceive alone is NOT sufficient - you must verify to collect evidence
-- Stop (done) ONLY after verifying every claim in the question
-- Do NOT repeat actions - check ACTION HISTORY before each action
-- Output valid JSON only
-- entity_id must match exactly from the DETECTED OBJECTS list
-- image_id must be "image_a" or "image_b"
-- For verify_count, object_class MUST be one of the exact names from OBJECT CLASSES FOR COUNTING"""
-
-        # Nova-specific prompt additions — Nova models tend to stop too early
-        if self.is_nova:
-            system_prompt += """
-
-CRITICAL ADDITIONAL RULES:
-- You MUST perform at least one verify_attribute, verify_relationship, or verify_count action BEFORE saying done
-- Do NOT say done after only perceive actions — perceive alone does NOT collect probabilistic evidence
-- If you are unsure what to verify, re-read the question carefully and identify ALL claims that need verification
-- If you tried to verify something and got a low probability, that IS valid evidence — do NOT stop because of low scores
-- You should typically perform 5-15 actions per question. If you have done fewer than 5, you are likely missing evidence
-- After each verify action, ask yourself: "Have I verified EVERY claim in the question?" If not, continue"""
+        system_prompt = self._build_system_prompt(image_ids)
 
         # Format candidates grouped by image
         candidates_text = self._format_candidates(candidates)
@@ -792,3 +680,164 @@ What is your next action? Output JSON only:"""
             lines.append("")  # Empty line between turns
 
         return "\n".join(lines).rstrip()
+
+    def _build_system_prompt(self, image_ids: List[str]) -> str:
+        """Build system prompt dynamically based on the number of images."""
+        n_images = len(image_ids)
+        multi_image = n_images > 1
+
+        # Image header
+        if n_images == 1:
+            image_word = "ONE image"
+            images_list = f"- Image A, image_id: {image_ids[0]}"
+        else:
+            image_word = f"{n_images} images"
+            image_labels = []
+            for img_id in image_ids:
+                letter = img_id.replace("image_", "").upper()
+                image_labels.append(f"- Image {letter}, image_id: {img_id}")
+            if n_images == 2:
+                image_labels[0] += " (the question may refer to Image A as the left or the first image)"
+                image_labels[1] += " (the question may refer to Image B as the right or the second image)"
+            images_list = "\n".join(image_labels)
+
+        # Valid image_id values for the rules section
+        valid_ids = ", ".join(f'"{i}"' for i in image_ids)
+
+        # Evidence chain examples — adapt based on single vs multi
+        chain_examples = """
+1. Count + Relationship: "At least one dog is sitting on the couch"
+   → Verify the count of dogs AND verify the "sitting on" relationship between dog and couch
+
+2. Count + Attribute: "There are two red cars"
+   → Verify the count of cars AND verify the "red" attribute for each car
+
+3. Attribute + Relationship: "The large cat is next to the bowl"
+   → Verify the "large" attribute for the cat AND verify the "next to" relationship between cat and bowl
+
+4. Multiple Attributes: "The car is red and shiny"
+   → Verify the "red" attribute AND verify the "shiny" attribute
+
+5. Relationship Chain: "The bird is on the branch which is above the water"
+   → Verify the "on" relationship between bird and branch AND verify the "above" relationship between branch and water"""
+
+        if multi_image:
+            chain_examples += """
+
+6. Count Comparison + Attribute: "There are more striped shirts in image A than B"
+   → Verify the count comparison between images AND verify the "striped" attribute for each of the shirts"""
+
+        # Example image_id for action examples
+        ex_img = image_ids[0]
+        ex_letter = ex_img.replace("image_", "")
+
+        # Count action section
+        count_section = f"""4. verify_count - Verify count-related queries. Returns probability (0.0-1.0).
+   Required fields: thought, action, query_type, object_class
+
+   Single-image queries (also requires: image_id, value):
+   - "at_least": P(count >= N) - {{"thought": "...", "action": "verify_count", "query_type": "at_least", "object_class": "dog", "image_id": "{ex_img}", "value": 2}}
+   - "at_most": P(count <= N) - {{"thought": "...", "action": "verify_count", "query_type": "at_most", "object_class": "dog", "image_id": "{ex_img}", "value": 2}}
+   - "exactly": P(count == N) - {{"thought": "...", "action": "verify_count", "query_type": "exactly", "object_class": "dog", "image_id": "{ex_img}", "value": 2}}"""
+
+        if multi_image:
+            img_a, img_b = image_ids[0], image_ids[1]
+            count_section += f"""
+
+   Cross-image comparison (also requires: image_id_a, image_id_b):
+   - "more": P(count_a > count_b) - {{"thought": "...", "action": "verify_count", "query_type": "more", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}"}}
+   - "fewer": P(count_a < count_b) - {{"thought": "...", "action": "verify_count", "query_type": "fewer", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}"}}
+   - "equal": P(count_a == count_b) - {{"thought": "...", "action": "verify_count", "query_type": "equal", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}"}}
+
+   Total across images (also requires: image_id_a, image_id_b, value):
+   - "total_exactly": P(total == N) - {{"thought": "...", "action": "verify_count", "query_type": "total_exactly", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}", "value": 5}}
+   - "total_at_least": P(total >= N) - {{"thought": "...", "action": "verify_count", "query_type": "total_at_least", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}", "value": 5}}
+   - "total_at_most": P(total <= N) - {{"thought": "...", "action": "verify_count", "query_type": "total_at_most", "object_class": "dog", "image_id_a": "{img_a}", "image_id_b": "{img_b}", "value": 5}}"""
+
+        system_prompt = f"""You are a ReAct evidence agent collecting evidence to answer a visual question about {image_word}.
+
+IMAGES:
+{images_list}
+
+GOAL:
+Collect all evidence required to answer the question. When done, the collected evidence alone should be sufficient to determine if the statement is true or false.
+
+EVIDENCE CHAINS:
+Questions often contain multiple connected claims. You must verify ALL parts of the chain.
+
+Common patterns:
+{chain_examples}
+
+Verifying only PART of a chain is INCOMPLETE - you must verify ALL parts.
+
+ACTIONS (output ONE as JSON):
+
+1. perceive - Ask open-ended question to gather information
+   Required fields: thought, action, image_id, question
+
+   Entity-level (also requires: entity_id):
+   - {{"thought": "I need to know the dog's color", "action": "perceive", "image_id": "{ex_img}", "entity_id": "dog_{ex_letter}_0", "question": "What color is this dog?"}}
+
+   Image-level (no entity_id needed):
+   - {{"thought": "I need to understand the scene", "action": "perceive", "image_id": "{ex_img}", "question": "What is happening in this image?"}}
+
+2. verify_attribute - Check if entity has specific attribute. Returns probability (0.0-1.0).
+   Required fields: thought, action, image_id, entity_id, attribute, verification
+   - attribute: the attribute being verified (e.g., "orange", "wooden", "showing teeth")
+   - verification: natural language describing the attribute (e.g., "an orange dog", "a dog showing its teeth")
+   Examples:
+   - {{"thought": "Verifying the dog is orange", "action": "verify_attribute", "image_id": "{ex_img}", "entity_id": "dog_{ex_letter}_0", "attribute": "orange", "verification": "an orange dog"}}
+
+3. verify_relationship - Check relationship between two entities in SAME image. Returns probability (0.0-1.0).
+   Supports both spatial relations (e.g., on, next to, left of, behind, above, etc.) and interactions (e.g., wearing, holding, eating, looking at, sitting on, etc.).
+   Required fields: thought, action, image_id, subject_id, object_id, relation, verification
+   - relation: the relationship being verified (e.g., "on top of", "wearing")
+   - verification: natural language describing the relationship (e.g., "a bird on top of a buffalo", "a man wearing a coat")
+   Examples:
+   - Spatial: {{"thought": "Checking if bird is on buffalo", "action": "verify_relationship", "image_id": "{ex_img}", "subject_id": "bird_{ex_letter}_0", "object_id": "buffalo_{ex_letter}_1", "relation": "on top of", "verification": "a bird on top of a buffalo"}}
+
+{count_section}
+
+5. done - Stop ONLY when ALL evidence has been collected
+   Required fields: thought, action
+   Example: {{"thought": "I have verified ALL attributes, relationships, and counts mentioned in the question", "action": "done"}}
+
+PERCEPTION SEMANTICS:
+- Perceive gathers contextual information to help you decide what to verify
+- Perceive does NOT collect probabilistic evidence - it only provides textual context
+- Image-level perceive: Use to understand the overall scene, context, or relationships in the whole image
+- Entity-level perceive: Use to gather specific information about a particular object
+- Use perceive to investigate, then verify to collect probabilistic evidence
+
+VERIFICATION SEMANTICS:
+- Verification returns a probability score (0.0-1.0) representing the model's confidence
+- This score is DETERMINISTIC - verifying the same thing again will return the same result
+- Low probability is valid evidence that something is likely FALSE
+- High probability is valid evidence that something is likely TRUE
+- Do NOT re-verify the same attribute or relationship - once you have the probability, that IS the evidence
+
+RULES:
+- COMPLETENESS IS REQUIRED: Verify ALL attributes, relationships, and counts in the question
+- Do NOT stop early - even if partial evidence seems sufficient to answer, you must verify everything
+- If the question mentions multiple entities/attributes, verify EACH ONE
+- Perceive alone is NOT sufficient - you must verify to collect evidence
+- Stop (done) ONLY after verifying every claim in the question
+- Do NOT repeat actions - check ACTION HISTORY before each action
+- Output valid JSON only
+- entity_id must match exactly from the DETECTED OBJECTS list
+- image_id must be one of: {valid_ids}
+- For verify_count, object_class MUST be one of the exact names from OBJECT CLASSES FOR COUNTING"""
+
+        # Nova-specific prompt additions — Nova models tend to stop too early
+        if self.is_nova:
+            system_prompt += """
+
+CRITICAL ADDITIONAL RULES:
+- You MUST perform at least one verify_attribute, verify_relationship, or verify_count action BEFORE saying done
+- Do NOT say done after only perceive actions — perceive alone does NOT collect probabilistic evidence
+- If you are unsure what to verify, re-read the question carefully and identify ALL claims that need verification
+- If you tried to verify something and got a low probability, that IS valid evidence — do NOT stop because of low scores
+- You should typically perform 5-15 actions per question. If you have done fewer than 5, you are likely missing evidence
+- After each verify action, ask yourself: "Have I verified EVERY claim in the question?" If not, continue"""
+
+        return system_prompt

--- a/src/prove.py
+++ b/src/prove.py
@@ -19,15 +19,17 @@ from .pipeline.problog_executor import ProbLogExecutor
 
 class PROVE:
     """
-    PROVE model for visual reasoning over image pairs.
+    PROVE model for visual reasoning over one or more images.
 
     Unified pipeline that always runs both probabilistic and deterministic modes
     with shared evidence to isolate the effect of perception uncertainty.
 
     Usage:
         model = PROVE()
-        result = model.predict("img1.jpg", "img2.jpg", "Is there a cat in both images?")
-        # result contains both probabilistic and deterministic answers
+        # Two images (NLVR2):
+        result = model.predict({"image_a": "img1.jpg", "image_b": "img2.jpg"}, "Is there a cat in both images?")
+        # Single image (GQA):
+        result = model.predict({"image_a": "img.jpg"}, "Is the dog brown?")
     """
 
     def __init__(self, threshold: float = 0.5):
@@ -58,16 +60,15 @@ class PROVE:
 
     def predict(
         self,
-        image_a_path: str,
-        image_b_path: str,
+        image_paths: Dict[str, str],
         question: str
     ) -> UnifiedResult:
         """
-        Run PROVE inference on image pair (unified pipeline).
+        Run PROVE inference on one or more images (unified pipeline).
 
         Args:
-            image_a_path: Path to first image
-            image_b_path: Path to second image
+            image_paths: Dict mapping image_id to file path
+                         e.g. {"image_a": "img1.jpg"} or {"image_a": "img1.jpg", "image_b": "img2.jpg"}
             question: Ultimate question to answer
 
         Returns:
@@ -77,12 +78,11 @@ class PROVE:
             FileNotFoundError: If image paths don't exist
             RuntimeError: If pipeline execution fails
         """
-        return self.predict_with_details(image_a_path, image_b_path, question)
+        return self.predict_with_details(image_paths, question)
 
     def predict_with_details(
         self,
-        image_a_path: str,
-        image_b_path: str,
+        image_paths: Dict[str, str],
         question: str,
         save_logs: bool = False,
         log_dir: str = "logs"
@@ -94,8 +94,7 @@ class PROVE:
         to isolate the effect of perception uncertainty.
 
         Args:
-            image_a_path: Path to first image
-            image_b_path: Path to second image
+            image_paths: Dict mapping image_id to file path
             question: Ultimate question to answer
             save_logs: Whether to save ProbLog and intermediate results
             log_dir: Base directory for logs (default: "logs")
@@ -112,17 +111,17 @@ class PROVE:
             RuntimeError: If pipeline execution fails
         """
         # Validate inputs
-        if not Path(image_a_path).exists():
-            raise FileNotFoundError(f"Image A not found: {image_a_path}")
-        if not Path(image_b_path).exists():
-            raise FileNotFoundError(f"Image B not found: {image_b_path}")
+        if not image_paths:
+            raise ValueError("image_paths must not be empty")
+        for image_id, path in image_paths.items():
+            if not Path(path).exists():
+                raise FileNotFoundError(f"{image_id} not found: {path}")
 
         # Initialize components
         self._init_components()
 
         # Initialize knowledge base
         kb = KnowledgeBase(ultimate_question=question)
-        image_paths = {"image_a": image_a_path, "image_b": image_b_path}
 
         try:
             # Print question
@@ -202,8 +201,9 @@ class PROVE:
                 # Copy images
                 images_dir = example_dir / "images"
                 images_dir.mkdir(exist_ok=True)
-                shutil.copy(image_a_path, images_dir / "image_a.jpg")
-                shutil.copy(image_b_path, images_dir / "image_b.jpg")
+                for img_id, img_path in image_paths.items():
+                    ext = Path(img_path).suffix or ".jpg"
+                    shutil.copy(img_path, images_dir / f"{img_id}{ext}")
 
                 # Save probabilistic ProbLog program
                 with open(example_dir / "probabilistic.pl", 'w') as f:


### PR DESCRIPTION
Generalize pipeline to handle arbitrary numbers of images instead of hardcoded image_a/image_b pairs. System prompts, ProbLog examples, and fallback queries now adapt dynamically based on image count. Add --dataset flag to run_eval.py with GQA data loading support.