### PR TITLE
Major clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ data/*
 nlvr2_results/
 nlvr2_results/*
 
-eval/
-eval/*
+/eval/
+/eval/*

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,0 +1,1 @@
+# Evaluation scripts for PROVE pipeline

--- a/src/eval/analyze_subsets.py
+++ b/src/eval/analyze_subsets.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Subset analysis — reads pre-computed PROVE/DePROVE predictions from all_results.json.
+Shows PROVE + per-LLM DePROVE for each subset.
+
+Usage:
+  python analyze_subsets.py llama=eval/v5_test1_llama/all_results.json \
+                            maverick=eval/v5_test1_maverick/all_results.json \
+                            mistral_large=eval/v5_test1_mistral_large/all_results.json
+"""
+import json, sys, argparse
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+
+parser = argparse.ArgumentParser(
+    description='Subset analysis from result files.',
+    epilog='Positional args: name=path pairs.')
+parser.add_argument('files', nargs='+', metavar='name=path',
+                    help='LLM result files as name=path')
+args = parser.parse_args()
+
+LLM_FILES = {}
+for spec in args.files:
+    if '=' not in spec:
+        parser.error(f"Expected name=path, got: {spec}")
+    name, path = spec.split('=', 1)
+    LLM_FILES[name] = path
+
+LLM_NAMES = list(LLM_FILES.keys())
+
+
+def to_bool_label(label):
+    if isinstance(label, bool): return label
+    if isinstance(label, str): return label.lower() in ('true', 'yes', '1')
+    return bool(label)
+
+
+# ─── Load data ────────────────────────────────────────────────────────────────
+
+print(f"LLMs: {', '.join(LLM_NAMES)}")
+print(f"Loading data from {len(LLM_FILES)} LLMs...", flush=True)
+
+all_labels = {}   # ident -> bool label
+llm_data = {}     # llm -> {ident: sample} (successful with posthoc predictions)
+
+for llm, path in LLM_FILES.items():
+    with open(path) as f:
+        data = json.load(f)
+    n_posthoc = 0
+    idx = {}
+    for s in data:
+        ident = s.get('identifier')
+        if not ident or s.get('label') is None:
+            continue
+        all_labels[ident] = to_bool_label(s['label'])
+        if s.get('success') and s.get('posthoc_prove_pred') is not None:
+            s['label'] = to_bool_label(s['label'])
+            idx[ident] = s
+            n_posthoc += 1
+    llm_data[llm] = idx
+    print(f"  {llm}: {n_posthoc} with posthoc predictions / {len(data)} total")
+
+all_ids = sorted(all_labels.keys())
+n = len(all_ids)
+print(f"  n = {n} (total samples in dataset)")
+
+# ─── Build per-sample data ────────────────────────────────────────────────────
+
+print("Building per-sample data...", flush=True)
+samples = []
+n_missing = 0
+
+for ident in all_ids:
+    label = all_labels[ident]
+
+    # Get per-LLM predictions from stored posthoc values
+    llm_prove_pred = {}
+    llm_prove_prob = {}
+    llm_dep_pred = {}
+    for llm in LLM_NAMES:
+        s = llm_data.get(llm, {}).get(ident)
+        if s is not None:
+            llm_prove_pred[llm] = s['posthoc_prove_pred']
+            llm_prove_prob[llm] = s.get('posthoc_prove_prob')
+            llm_dep_pred[llm] = s['posthoc_deprove_pred']
+        else:
+            llm_prove_pred[llm] = None
+            llm_prove_prob[llm] = None
+            llm_dep_pred[llm] = None
+
+    n_valid = sum(1 for l in LLM_NAMES if llm_prove_pred[l] is not None)
+    if n_valid < len(LLM_NAMES):
+        n_missing += 1
+
+    # Get a raw sample for feature extraction (from any available LLM)
+    raw = None
+    for llm in LLM_NAMES:
+        raw = llm_data.get(llm, {}).get(ident)
+        if raw is not None:
+            break
+    if raw is None:
+        continue
+
+    # PROVE ensemble: perlm_soft — avg probs over valid LLMs
+    valid_probs = [llm_prove_prob[l] for l in LLM_NAMES if llm_prove_prob[l] is not None]
+    valid_preds = [llm_prove_pred[l] for l in LLM_NAMES if llm_prove_pred[l] is not None]
+    if valid_preds:
+        # Majority of per-LLM predictions
+        prove_pred = sum(valid_preds) > len(valid_preds) / 2
+    else:
+        prove_pred = not label  # all missing = wrong
+
+    # Per-LLM DePROVE predictions (missing = wrong)
+    dep_preds = {l: llm_dep_pred[l] if llm_dep_pred[l] is not None else (not label) for l in LLM_NAMES}
+    dep_majority = sum(dep_preds[l] for l in LLM_NAMES) > len(LLM_NAMES) / 2
+
+    # Extract features from raw sample
+    rules = raw.get('problog', {}).get('rules', '')
+    evidence = raw.get('evidence', {})
+    facts = raw.get('problog', {}).get('facts', [])
+
+    n_attr = sum(1 for f in facts if f.get('predicate') == 'attribute')
+    n_rel = sum(1 for f in facts if f.get('predicate') == 'relation')
+    n_total_facts = len(facts)
+    n_vqa_facts = n_attr + n_rel
+
+    fact_probs = [f.get('probability', 0.5) for f in facts if f.get('predicate') != 'entity']
+    avg_fact_prob = sum(fact_probs) / max(len(fact_probs), 1) if fact_probs else 0.5
+
+    high_conf = sum(1 for p in fact_probs if p > 0.7 or p < 0.3) if fact_probs else 0
+    high_conf_ratio = high_conf / max(len(fact_probs), 1)
+
+    uncertain_count = sum(1 for p in fact_probs if 0.3 <= p <= 0.7) if fact_probs else 0
+
+    has_negation = '\\+' in rules
+    has_disjunction = ';' in rules
+    n_helper_rules = max(0, rules.count(':-') - 1) if rules else 0
+
+    # VQA agreement: BLIP vs Qwen TF
+    agree_tf = 0
+    disagree_tf = 0
+    for ev_list in [evidence.get('attributes', []), evidence.get('relationships', [])]:
+        for ev in ev_list:
+            b = ev.get('blip_score')
+            q = ev.get('qwen_tf_score')
+            if b is not None and q is not None:
+                if (b >= 0.5) == (q >= 0.5):
+                    agree_tf += 1
+                else:
+                    disagree_tf += 1
+    agreement_tf_ratio = agree_tf / max(agree_tf + disagree_tf, 1)
+
+    # LLM PROVE probability gap
+    prove_vals = [llm_prove_prob[l] for l in LLM_NAMES if llm_prove_prob[l] is not None]
+    prove_gap = (max(prove_vals) - min(prove_vals)) if len(prove_vals) >= 2 else 0.0
+
+    # LLMs disagree on PROVE direction (using stored per-LLM predictions)
+    llm_dirs = [llm_prove_pred[l] for l in LLM_NAMES if llm_prove_pred[l] is not None]
+    llms_disagree = bool(llm_dirs) and not (all(llm_dirs) or not any(llm_dirs))
+
+    all_dep_wrong = all(dep_preds[l] != label for l in LLM_NAMES)
+
+    samples.append({
+        'ident': ident,
+        'label': label,
+        'prove_pred': prove_pred,
+        'dep_preds': dep_preds,
+        'dep_majority': dep_majority,
+        'n_total_facts': n_total_facts,
+        'has_negation': has_negation,
+        'has_disjunction': has_disjunction,
+        'n_helper_rules': n_helper_rules,
+        'prove_gap': prove_gap,
+        'llms_disagree': llms_disagree,
+        'all_dep_wrong': all_dep_wrong,
+        'avg_fact_prob': avg_fact_prob,
+        'high_conf_ratio': high_conf_ratio,
+        'uncertain_count': uncertain_count,
+        'agreement_tf_ratio': agreement_tf_ratio,
+        'n_attr': n_attr,
+        'n_rel': n_rel,
+        'n_vqa_facts': n_vqa_facts,
+    })
+
+print(f"  {len(samples)} samples ({n_missing} partial)\n")
+
+# ─── Subset definitions ──────────────────────────────────────────────────────
+
+SUBSETS = {
+    'Label': {
+        'True': lambda s: s['label'] == True,
+        'False': lambda s: s['label'] == False,
+    },
+    'Fact Count': {
+        'Few (1-5)': lambda s: s['n_total_facts'] <= 5,
+        'Medium (6-10)': lambda s: 5 < s['n_total_facts'] <= 10,
+        'Many (11+)': lambda s: s['n_total_facts'] > 10,
+    },
+    'VQA Fact Count': {
+        '<=2 VQA facts': lambda s: s['n_vqa_facts'] <= 2,
+        '3-5 VQA facts': lambda s: 3 <= s['n_vqa_facts'] <= 5,
+        '>=6 VQA facts': lambda s: s['n_vqa_facts'] >= 6,
+    },
+    'Fact Type': {
+        'Attrs only': lambda s: s['n_attr'] > 0 and s['n_rel'] == 0 and s['n_vqa_facts'] > 0,
+        'Rels only': lambda s: s['n_rel'] > 0 and s['n_attr'] == 0,
+        'Attrs + Rels': lambda s: s['n_attr'] > 0 and s['n_rel'] > 0,
+        'Count only': lambda s: s['n_vqa_facts'] == 0,
+    },
+    'Relation Count': {
+        '0 relations': lambda s: s['n_rel'] == 0,
+        '1 relation': lambda s: s['n_rel'] == 1,
+        '2+ relations': lambda s: s['n_rel'] >= 2,
+    },
+    'ProbLog Negation': {
+        'Contains negation': lambda s: s['has_negation'],
+        'No negation': lambda s: not s['has_negation'],
+    },
+    'ProbLog Disjunction': {
+        'Has disjunction': lambda s: s['has_disjunction'],
+        'Conjunction only': lambda s: not s['has_disjunction'],
+    },
+    'Helper Rules': {
+        '0 helpers': lambda s: s['n_helper_rules'] == 0,
+        '1 helper': lambda s: s['n_helper_rules'] == 1,
+        '2+ helpers': lambda s: s['n_helper_rules'] >= 2,
+    },
+    'Confidence (decisive facts)': {
+        'High conf (>70% decisive)': lambda s: s['high_conf_ratio'] > 0.7,
+        'Mixed conf': lambda s: 0.3 <= s['high_conf_ratio'] <= 0.7,
+        'Low conf (<30% decisive)': lambda s: s['high_conf_ratio'] < 0.3,
+    },
+    'Avg Fact Probability': {
+        'High (>0.7)': lambda s: s['avg_fact_prob'] > 0.7,
+        'Medium (0.4-0.7)': lambda s: 0.4 <= s['avg_fact_prob'] <= 0.7,
+        'Low (<0.4)': lambda s: s['avg_fact_prob'] < 0.4,
+    },
+    'Uncertain Facts (0.3-0.7)': {
+        '0 uncertain': lambda s: s['uncertain_count'] == 0,
+        '1-2 uncertain': lambda s: 1 <= s['uncertain_count'] <= 2,
+        '3+ uncertain': lambda s: s['uncertain_count'] >= 3,
+    },
+    'VQA Agreement (BLIP vs Qwen TF)': {
+        'High agree TF (>80%)': lambda s: s['agreement_tf_ratio'] > 0.8,
+        'Mod agree TF (50-80%)': lambda s: 0.5 < s['agreement_tf_ratio'] <= 0.8,
+        'Low agree TF (<=50%)': lambda s: s['agreement_tf_ratio'] <= 0.5,
+    },
+    'LLM Probability Gap': {
+        'Large gap (>=0.5)': lambda s: s['prove_gap'] >= 0.5,
+        'Medium gap (0.2-0.5)': lambda s: 0.2 <= s['prove_gap'] < 0.5,
+        'Small gap (<0.2)': lambda s: s['prove_gap'] < 0.2,
+    },
+    'LLM PROVE Direction': {
+        'LLMs disagree (mixed dirs)': lambda s: s['llms_disagree'],
+        'LLMs agree': lambda s: not s['llms_disagree'],
+    },
+    'DePROVE Correctness': {
+        'All 3 DePROVE wrong': lambda s: s['all_dep_wrong'],
+        'At least 1 DePROVE right': lambda s: not s['all_dep_wrong'],
+    },
+}
+
+
+# ─── Print analysis ──────────────────────────────────────────────────────────
+
+def print_subset(name, subset_samples):
+    ns = len(subset_samples)
+    if ns == 0:
+        return
+
+    prove_correct = sum(1 for s in subset_samples if s['prove_pred'] == s['label'])
+    prove_acc = 100 * prove_correct / ns
+
+    dep_accs = {}
+    for llm in LLM_NAMES:
+        dep_correct = sum(1 for s in subset_samples if s['dep_preds'][llm] == s['label'])
+        dep_accs[llm] = 100 * dep_correct / ns
+
+    maj_correct = sum(1 for s in subset_samples if s['dep_majority'] == s['label'])
+    maj_acc = 100 * maj_correct / ns
+
+    dep_parts = "  ".join(f"DeP({llm[:3].title()})={dep_accs[llm]:5.1f}%" for llm in LLM_NAMES)
+    print(f"  {name:40s} n={ns:4d} | PROVE={prove_acc:5.1f}%  {dep_parts}  DeP(Maj)={maj_acc:5.1f}%")
+
+
+print(f"{'='*120}")
+print(f"SUBSET ANALYSIS")
+print(f"  LLMs: {', '.join(LLM_NAMES)}")
+print(f"{'='*120}")
+print()
+print_subset("OVERALL", samples)
+
+for group_name, subsets in SUBSETS.items():
+    print(f"\n  --- {group_name} ---")
+    for subset_name, filter_fn in subsets.items():
+        filtered = [s for s in samples if filter_fn(s)]
+        print_subset(subset_name, filtered)
+
+# ─── PROVE vs best-DePROVE delta per subset ──────────────────────────────────
+
+print(f"\n\n{'='*120}")
+print(f"PROVE vs BEST SINGLE-LLM DePROVE (delta)")
+print(f"{'='*120}")
+
+def print_delta(name, subset_samples):
+    ns = len(subset_samples)
+    if ns == 0:
+        return
+    prove_acc = 100 * sum(1 for s in subset_samples if s['prove_pred'] == s['label']) / ns
+    best_dep = max(
+        100 * sum(1 for s in subset_samples if s['dep_preds'][l] == s['label']) / ns
+        for l in LLM_NAMES
+    )
+    maj_acc = 100 * sum(1 for s in subset_samples if s['dep_majority'] == s['label']) / ns
+    delta_best = prove_acc - best_dep
+    delta_maj = prove_acc - maj_acc
+    print(f"  {name:40s} n={ns:4d} | PROVE={prove_acc:5.1f}%  BestDeP={best_dep:5.1f}%  Maj={maj_acc:5.1f}%  d(best)={delta_best:+5.1f}%  d(maj)={delta_maj:+5.1f}%")
+
+print()
+print_delta("OVERALL", samples)
+for group_name, subsets in SUBSETS.items():
+    print(f"\n  --- {group_name} ---")
+    for subset_name, filter_fn in subsets.items():
+        filtered = [s for s in samples if filter_fn(s)]
+        print_delta(subset_name, filtered)

--- a/src/eval/configs.json
+++ b/src/eval/configs.json
@@ -1,0 +1,30 @@
+{
+  "v5_perlm": {
+    "description": "Best per-LLM config (v5 sweep)",
+    "threshold": {"base": 0.45, "slope": -0.1},
+    "llm_configs": {
+      "llama":         {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                        "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"},
+      "maverick":      {"attr_score_type": "qwen_tf_score", "rel_score_type": "avg_blip_qwen_tf",
+                        "entity_prob": 1.0, "dampened_alpha": 0.9, "agreement_mode": "sharpen"},
+      "mistral_large": {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                        "entity_prob": null, "dampened_alpha": 0.9, "agreement_mode": "sharpen"}
+    },
+    "fallback": {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                 "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"}
+  },
+  "shared_best": {
+    "description": "Best shared config (qwen_tf, ep=1.0, da=1.0, sharpen)",
+    "threshold": {"base": 0.45, "slope": -0.1},
+    "llm_configs": {
+      "llama":         {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                        "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"},
+      "maverick":      {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                        "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"},
+      "mistral_large": {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                        "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"}
+    },
+    "fallback": {"attr_score_type": "qwen_tf_score", "rel_score_type": "qwen_tf_score",
+                 "entity_prob": 1.0, "dampened_alpha": 1.0, "agreement_mode": "sharpen"}
+  }
+}

--- a/src/eval/eval_gaussian_ablation.py
+++ b/src/eval/eval_gaussian_ablation.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Ablation: replace all VQA fact probabilities with Gaussian random values.
+Tests whether PROVE's advantage comes from actual scores or ProbLog structure.
+Runs multiple seeds and reports mean ± std.
+"""
+import json, math, sys, os, time, signal
+import multiprocessing as mp
+import numpy as np
+
+from pathlib import Path
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, _PROJECT_ROOT)
+
+from src.eval.problog_utils import (
+    SemiringDampened, execute_problog_direct, threshold_fn,
+)
+
+import argparse
+
+BASE = _PROJECT_ROOT
+LLM_NAMES = ['llama', 'maverick', 'mistral_large']
+
+SCORE_CONFIGS = {
+    'llama': {'dampened_alpha': 1.0},
+    'maverick': {'dampened_alpha': 0.9},
+    'mistral_large': {'dampened_alpha': 0.9},
+}
+
+DATASET_PATHS = {
+    'test1': {
+        'llm_files': {
+            'llama': f'{BASE}/eval/v5_baseline_llama/all_results.json',
+            'maverick': f'{BASE}/eval/v5_baseline_maverick/all_results.json',
+            'mistral_large': f'{BASE}/eval/v5_baseline_mistral_large/all_results.json',
+        },
+        'extra_label_files': {
+            'nova_pro': f'{BASE}/eval/v5_baseline_nova_pro/all_results.json',
+            'nova_premier': f'{BASE}/eval/v5_baseline_nova_premier/all_results.json',
+        },
+    },
+    'test2': {
+        'llm_files': {
+            'llama': f'{BASE}/eval/v5_test2_llama/all_results.json',
+            'maverick': f'{BASE}/eval/v5_test2_maverick/all_results.json',
+            'mistral_large': f'{BASE}/eval/v5_test2_mistral_large/all_results.json',
+        },
+        'extra_label_files': {},
+    },
+    'gqa': {
+        'llm_files': {
+            'llama': f'{BASE}/eval/v5_flex_gqa_llama/all_results.json',
+            'maverick': f'{BASE}/eval/v5_flex_gqa_maverick/all_results.json',
+            'mistral_large': f'{BASE}/eval/v5_flex_gqa_mistral_large/all_results.json',
+        },
+        'extra_label_files': {},
+    },
+}
+
+THRESH_BASE = 0.45
+THRESH_SLOPE = -0.1
+NUM_SEEDS = 20
+GAUSS_MEAN = 0.5
+GAUSS_STD = 0.2
+
+
+
+
+def _alarm_handler(signum, frame):
+    raise TimeoutError("ProbLog timed out")
+
+
+def _worker(args):
+    llm, ident, sample, da, seed = args
+
+    stored_facts = sample.get('problog', {}).get('facts', [])
+    rules = sample.get('problog', {}).get('rules', '')
+    query = sample.get('problog', {}).get('query', '')
+    if not stored_facts or not rules or not query:
+        return (llm, ident, seed, None, None, 0)
+
+    # Replace non-entity fact probs with Gaussian random values
+    rng = np.random.RandomState(hash((ident, llm, seed)) % (2**31))
+    facts = []
+    for fact in stored_facts:
+        pred = fact.get('predicate', '')
+        if pred == 'entity':
+            # Keep entity prob as-is (from original pipeline)
+            prob = fact.get('probability', 0.5)
+        else:
+            # Random Gaussian probability
+            prob = rng.normal(GAUSS_MEAN, GAUSS_STD)
+        prob = max(1e-7, min(1 - 1e-7, prob))
+        facts.append({**fact, 'probability': prob})
+
+    sr = SemiringDampened(alpha=da) if da != 1.0 else None
+
+    old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+    signal.alarm(30)
+    try:
+        prove_prob = execute_problog_direct(facts, rules, query, semiring=sr)
+        dep_facts = [{**f, 'probability': 1.0 if f['probability'] >= 0.5 else 0.0} for f in facts]
+        dep_prob = execute_problog_direct(dep_facts, rules, query, semiring=None)
+    except TimeoutError:
+        prove_prob = None
+        dep_prob = None
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
+
+    return (llm, ident, seed, prove_prob, dep_prob, len(facts))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', default='test1', choices=['test1', 'test2', 'gqa'])
+    args = parser.parse_args()
+
+    ds = DATASET_PATHS[args.dataset]
+    LLM_FILES = ds['llm_files']
+    ALL_LLM_FILES = {**LLM_FILES, **ds['extra_label_files']}
+
+    t0 = time.time()
+    print("=" * 100)
+    print(f"GAUSSIAN ABLATION ({args.dataset.upper()}): N({GAUSS_MEAN}, {GAUSS_STD}), {NUM_SEEDS} seeds")
+    print("=" * 100)
+
+    # Load labels
+    print("\nLoading labels from all LLMs (union)...", flush=True)
+    all_labels = {}
+    for llm, path in ALL_LLM_FILES.items():
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            for s in data:
+                ident = s.get('identifier')
+                if ident and s.get('success') and s.get('label') is not None:
+                    all_labels[ident] = s['label']
+        except FileNotFoundError:
+            pass
+
+    # Load raw samples
+    llm_raw = {}
+    for llm, path in LLM_FILES.items():
+        with open(path) as f:
+            data = json.load(f)
+        idx = {}
+        for s in data:
+            ident = s.get('identifier')
+            if ident and s.get('success') and s.get('label') is not None:
+                idx[ident] = s
+        llm_raw[llm] = idx
+
+    all_ids = sorted(all_labels.keys())
+    n = len(all_ids)
+    labels_arr = np.array([all_labels[ident] for ident in all_ids], dtype=bool)
+    print(f"  n = {n}")
+
+    # Build work items: all LLMs × all samples × all seeds
+    work_items = []
+    for seed in range(NUM_SEEDS):
+        for llm in LLM_NAMES:
+            da = SCORE_CONFIGS[llm]['dampened_alpha']
+            for ident in all_ids:
+                sample = llm_raw.get(llm, {}).get(ident)
+                if sample is not None:
+                    work_items.append((llm, ident, sample, da, seed))
+
+    print(f"  {len(work_items)} work items ({NUM_SEEDS} seeds × 3 LLMs × ~{n} samples)")
+    print(f"  Using {os.cpu_count()} workers...", flush=True)
+
+    # results[seed][llm][ident] = (prove_prob, dep_prob, n_facts)
+    results = {s: {l: {} for l in LLM_NAMES} for s in range(NUM_SEEDS)}
+
+    with mp.Pool(min(os.cpu_count() or 4, 90), maxtasksperchild=50) as pool:
+        for i, result in enumerate(pool.imap_unordered(_worker, work_items, chunksize=20)):
+            llm, ident, seed, prove_prob, dep_prob, n_facts = result
+            if prove_prob is not None:
+                results[seed][llm][ident] = (prove_prob, dep_prob, n_facts)
+            if (i + 1) % 5000 == 0:
+                print(f"    {i+1}/{len(work_items)} ({time.time()-t0:.0f}s)", flush=True)
+
+    print(f"\n  Precomputation done in {time.time()-t0:.0f}s\n")
+
+    # Compute accuracy per seed
+    prove_accs = []
+    dep_accs_per_llm = {l: [] for l in LLM_NAMES}
+    dep_majority_accs = []
+
+    for seed in range(NUM_SEEDS):
+        prove_arr = np.full((3, n), np.nan)
+        deprove_arr = np.full((3, n), np.nan)
+        nfacts_arr = np.zeros((3, n))
+
+        for j, llm in enumerate(LLM_NAMES):
+            cache = results[seed][llm]
+            for i, ident in enumerate(all_ids):
+                entry = cache.get(ident)
+                if entry is not None and entry[0] is not None:
+                    prove_arr[j, i] = entry[0]
+                    deprove_arr[j, i] = entry[1] if entry[1] is not None else np.nan
+                    nfacts_arr[j, i] = entry[2]
+
+        valid_mask = ~np.isnan(prove_arr)
+        valid_count = valid_mask.sum(axis=0)
+        any_valid = valid_count > 0
+        vc = np.maximum(valid_count, 1)
+
+        # PROVE (perlm_soft)
+        pp_safe = np.where(valid_mask, prove_arr, 0.0)
+        avg_pp = pp_safe.sum(axis=0) / vc
+        nf_safe = np.where(valid_mask, nfacts_arr, 0.0)
+        avg_nf = nf_safe.sum(axis=0) / vc
+        thresholds = np.array([threshold_fn(nf, THRESH_BASE, THRESH_SLOPE) for nf in avg_nf])
+        prove_pred = avg_pp >= thresholds
+        prove_pred[~any_valid] = ~labels_arr[~any_valid]
+        prove_acc = (prove_pred == labels_arr).sum() / n
+        prove_accs.append(prove_acc)
+
+        # Per-LLM DePROVE
+        dep_preds_all = {}
+        for j, llm in enumerate(LLM_NAMES):
+            vm = valid_mask[j]
+            dp = deprove_arr[j] >= 0.5
+            dp[~vm] = ~labels_arr[~vm]
+            dep_accs_per_llm[llm].append((dp == labels_arr).sum() / n)
+            dep_preds_all[llm] = dp
+
+        # Majority vote
+        dep_votes = np.stack([dep_preds_all[l] for l in LLM_NAMES], axis=0)
+        majority_pred = dep_votes.sum(axis=0) >= 2
+        dep_majority_accs.append((majority_pred == labels_arr).sum() / n)
+
+    # Report
+    print("=" * 100)
+    print(f"  RESULTS: Gaussian N({GAUSS_MEAN}, {GAUSS_STD}), {NUM_SEEDS} seeds")
+    print("=" * 100)
+
+    prove_mean = 100 * np.mean(prove_accs)
+    prove_std = 100 * np.std(prove_accs)
+    print(f"\n  PROVE (perlm_soft):      {prove_mean:.2f}% ± {prove_std:.2f}%")
+
+    for llm in LLM_NAMES:
+        m = 100 * np.mean(dep_accs_per_llm[llm])
+        s = 100 * np.std(dep_accs_per_llm[llm])
+        short = {'llama': 'Llama', 'maverick': 'Maverick', 'mistral_large': 'Mistral Large'}
+        print(f"  DePROVE ({short[llm]:14s}): {m:.2f}% ± {s:.2f}%")
+
+    maj_m = 100 * np.mean(dep_majority_accs)
+    maj_s = 100 * np.std(dep_majority_accs)
+    print(f"  DePROVE (Majority Vote): {maj_m:.2f}% ± {maj_s:.2f}%")
+
+    # Also show per-seed for reference
+    print(f"\n  Per-seed PROVE: {['%.1f' % (100*a) for a in prove_accs]}")
+
+    # Compare to real numbers
+    real_prove = {'test1': 73.06, 'test2': 73.92, 'gqa': 63.99}
+    real_dep = {'test1': 69.95, 'test2': 69.77, 'gqa': 61.02}
+    print(f"\n  For reference — real PROVE: {real_prove.get(args.dataset, '?')}%, real best DePROVE: {real_dep.get(args.dataset, '?')}%")
+
+    print(f"\n\nTotal time: {time.time()-t0:.0f}s")

--- a/src/eval/print_all_results.py
+++ b/src/eval/print_all_results.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""
+Comprehensive results printer for the PROVE project.
+Reads all experiment result JSON files and prints formatted ASCII tables.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+BASE = _PROJECT_ROOT / "eval"
+
+# ============================================================================
+# Utility functions
+# ============================================================================
+
+def load_json(path):
+    """Load a JSON file, return None if it doesn't exist."""
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def hline(width=100, char="="):
+    return char * width
+
+
+def section(title, width=100):
+    print()
+    print(hline(width))
+    print(f"  {title}")
+    print(hline(width))
+
+
+def subsection(title, width=100):
+    print()
+    print(f"  --- {title} ---")
+
+
+def fmt_pct(val, width=7):
+    """Format a float as percentage string."""
+    if val is None:
+        return "   N/A ".rjust(width)
+    return f"{val*100:.2f}%".rjust(width)
+
+
+def fmt_float(val, width=8):
+    if val is None:
+        return "    N/A ".rjust(width)
+    return f"{val:.4f}".rjust(width)
+
+
+def fmt_int(val, width=6):
+    if val is None:
+        return "  N/A ".rjust(width)
+    return str(val).rjust(width)
+
+
+# ============================================================================
+# 1. Baselines: compute from raw samples
+# ============================================================================
+
+def compute_baseline(data, name):
+    """Compute PROVE/DePROVE accuracy from raw sample results."""
+    n_total = len(data)
+    n_success = 0
+    n_valid = 0
+    prove_correct = 0
+    deprove_correct = 0
+    # For McNemar: count discordant pairs
+    prove_right_deprove_wrong = 0
+    prove_wrong_deprove_right = 0
+
+    for item in data:
+        if not item.get("success"):
+            continue
+        n_success += 1
+
+        results = item.get("results", {})
+        if results.get("prove_prob") is None:
+            continue
+        n_valid += 1
+
+        label = item["label"]  # bool
+        prove_ans = results.get("prove_answer", "")
+        deprove_ans = results.get("deprove_answer", "")
+
+        # Convert string answers to bool
+        prove_pred = prove_ans.strip().lower() == "true" if isinstance(prove_ans, str) else bool(prove_ans)
+        deprove_pred = deprove_ans.strip().lower() == "true" if isinstance(deprove_ans, str) else bool(deprove_ans)
+
+        p_correct = (prove_pred == label)
+        d_correct = (deprove_pred == label)
+
+        if p_correct:
+            prove_correct += 1
+        if d_correct:
+            deprove_correct += 1
+
+        if p_correct and not d_correct:
+            prove_right_deprove_wrong += 1
+        elif not p_correct and d_correct:
+            prove_wrong_deprove_right += 1
+
+    prove_acc = prove_correct / n_valid if n_valid > 0 else None
+    deprove_acc = deprove_correct / n_valid if n_valid > 0 else None
+
+    # McNemar chi2 (without continuity correction)
+    b = prove_right_deprove_wrong
+    c = prove_wrong_deprove_right
+    if (b + c) > 0:
+        chi2 = (b - c) ** 2 / (b + c)
+    else:
+        chi2 = 0.0
+
+    return {
+        "name": name,
+        "n_total": n_total,
+        "n_success": n_success,
+        "n_valid": n_valid,
+        "prove_acc": prove_acc,
+        "deprove_acc": deprove_acc,
+        "delta": (prove_acc - deprove_acc) if prove_acc is not None and deprove_acc is not None else None,
+        "chi2": chi2,
+        "prove_wins": b,
+        "deprove_wins": c,
+    }
+
+
+def print_baselines():
+    section("1. BASELINE RESULTS (raw sample computation)")
+
+    baselines = [
+        (BASE / "v3_baseline_maverick" / "all_results.json", "Maverick (v3)"),
+        (BASE / "v3_baseline_llama" / "all_results.json", "Llama 3.3 70B (v3)"),
+        (BASE / "nova_pro_cot" / "all_results.json", "Nova Pro CoT"),
+    ]
+
+    results = []
+    for path, name in baselines:
+        data = load_json(path)
+        if data is None:
+            print(f"  [MISSING] {path}")
+            continue
+        r = compute_baseline(data, name)
+        results.append(r)
+
+    if not results:
+        print("  No baseline files found.")
+        return
+
+    # Print table
+    header = f"  {'Model':<22s} {'N':>6s} {'PROVE':>8s} {'DePROVE':>8s} {'Delta':>8s} {'Chi2':>8s} {'Sig?':>5s} {'P>D':>5s} {'D>P':>5s}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for r in results:
+        sig = "Yes" if r["chi2"] > 3.84 else "No"
+        delta_str = fmt_pct(r["delta"])
+        print(f"  {r['name']:<22s} {r['n_valid']:>6d} {fmt_pct(r['prove_acc'])} {fmt_pct(r['deprove_acc'])} {delta_str} {r['chi2']:>8.3f} {sig:>5s} {r['prove_wins']:>5d} {r['deprove_wins']:>5d}")
+
+    print()
+    print("  Legend: N=valid samples, Delta=PROVE-DePROVE, Chi2=McNemar, Sig=Chi2>3.84, P>D=prove-only-correct, D>P=deprove-only-correct")
+
+
+# ============================================================================
+# Config analysis helpers
+# ============================================================================
+
+def analyze_configs(data, name, chi2_key="chi2"):
+    """Analyze a configurations dict. Returns summary and top configs."""
+    configs = data.get("configurations", {})
+    n_total = len(configs)
+    n_sig_prove = 0  # chi2 > 3.84 AND prove_acc > deprove_acc
+    n_sig_deprove = 0  # chi2 > 3.84 AND deprove_acc > prove_acc
+
+    all_configs = []
+    for key, c in configs.items():
+        chi2 = c.get(chi2_key, c.get("chi2", 0))
+        prove_acc = c.get("prove_acc", 0)
+        deprove_acc = c.get("deprove_acc", 0)
+        delta = prove_acc - deprove_acc
+        n = c.get("n_samples", 0)
+
+        if chi2 > 3.84:
+            if prove_acc > deprove_acc:
+                n_sig_prove += 1
+            elif deprove_acc > prove_acc:
+                n_sig_deprove += 1
+
+        all_configs.append({
+            "key": key,
+            "prove_acc": prove_acc,
+            "deprove_acc": deprove_acc,
+            "delta": delta,
+            "chi2": chi2,
+            "n": n,
+        })
+
+    # Sort by delta (PROVE > DePROVE)
+    by_delta = sorted(all_configs, key=lambda x: x["delta"], reverse=True)
+    # Sort by chi2 where PROVE > DePROVE
+    prove_better = [c for c in all_configs if c["delta"] > 0]
+    by_chi2 = sorted(prove_better, key=lambda x: x["chi2"], reverse=True)
+
+    return {
+        "name": name,
+        "n_total": n_total,
+        "n_sig_prove": n_sig_prove,
+        "n_sig_deprove": n_sig_deprove,
+        "top_by_delta": by_delta[:5],
+        "top_by_chi2": by_chi2[:5],
+    }
+
+
+def print_config_table(analysis, show_top=True):
+    """Print analysis for a configurations experiment."""
+    a = analysis
+    subsection(f"{a['name']} ({a['n_total']} configs)")
+    print(f"  Total configs: {a['n_total']}")
+    print(f"  Significant PROVE > DePROVE (chi2>3.84): {a['n_sig_prove']}")
+    print(f"  Significant DePROVE > PROVE (chi2>3.84): {a['n_sig_deprove']}")
+
+    if show_top and a["top_by_delta"]:
+        print()
+        print(f"  Top 5 by gap (PROVE - DePROVE):")
+        header = f"    {'Config':<72s} {'PROVE':>7s} {'DePROVE':>8s} {'Delta':>7s} {'Chi2':>8s} {'N':>5s}"
+        print(header)
+        print("    " + "-" * (len(header) - 4))
+        for c in a["top_by_delta"]:
+            key = c["key"][:70]
+            print(f"    {key:<72s} {fmt_pct(c['prove_acc'])} {fmt_pct(c['deprove_acc'])} {fmt_pct(c['delta'])} {c['chi2']:>8.3f} {c['n']:>5d}")
+
+    if show_top and a["top_by_chi2"]:
+        print()
+        print(f"  Top 5 by chi2 (PROVE > DePROVE only):")
+        header = f"    {'Config':<72s} {'PROVE':>7s} {'DePROVE':>8s} {'Delta':>7s} {'Chi2':>8s} {'N':>5s}"
+        print(header)
+        print("    " + "-" * (len(header) - 4))
+        for c in a["top_by_chi2"]:
+            key = c["key"][:70]
+            print(f"    {key:<72s} {fmt_pct(c['prove_acc'])} {fmt_pct(c['deprove_acc'])} {fmt_pct(c['delta'])} {c['chi2']:>8.3f} {c['n']:>5d}")
+
+
+# ============================================================================
+# 2. Threshold sweep
+# ============================================================================
+
+def print_threshold_sweep():
+    section("2. v3_threshold_sweep RESULTS")
+
+    files = [
+        (BASE / "v3_threshold_sweep" / "maverick_results.json", "Maverick"),
+        (BASE / "v3_threshold_sweep" / "llama_results.json", "Llama 3.3 70B"),
+    ]
+
+    for path, name in files:
+        data = load_json(path)
+        if data is None:
+            print(f"  [MISSING] {path}")
+            continue
+
+        thresholds = data.get("thresholds", [])
+        subsection(f"{name} ({len(thresholds)} thresholds)")
+
+        header = f"  {'Thresh':>7s} {'PROVE':>8s} {'DePROVE':>8s} {'Delta':>8s} {'Chi2':>8s} {'Sig?':>5s} {'P>D':>5s} {'D>P':>5s} {'N':>5s}"
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for t in thresholds:
+            thr = t.get("threshold", t.get("prove_threshold", "?"))
+            prove = t.get("prove_acc", 0)
+            deprove = t.get("deprove_acc", 0)
+            delta = prove - deprove
+            chi2 = t.get("chi2", 0)
+            sig = "Yes" if chi2 > 3.84 else "No"
+            pw = t.get("prove_wins", 0)
+            dw = t.get("deprove_wins", 0)
+            n = t.get("n_samples", 0)
+            print(f"  {thr:>7.2f} {fmt_pct(prove)} {fmt_pct(deprove)} {fmt_pct(delta)} {chi2:>8.3f} {sig:>5s} {pw:>5d} {dw:>5d} {n:>5d}")
+
+
+# ============================================================================
+# 3. Dynamic threshold (BUGGY)
+# ============================================================================
+
+def print_dynamic_threshold():
+    section("3. v3_dynamic_threshold RESULTS [BUGGY -- DePROVE uses dynamic threshold instead of fixed 0.5]")
+
+    files = [
+        (BASE / "v3_dynamic_threshold" / "maverick_results.json", "Maverick"),
+        (BASE / "v3_dynamic_threshold" / "llama_results.json", "Llama 3.3 70B"),
+    ]
+
+    for path, name in files:
+        data = load_json(path)
+        if data is None:
+            print(f"  [MISSING] {path}")
+            continue
+
+        strategies = data.get("strategies", [])
+        subsection(f"{name} [BUGGY] ({len(strategies)} strategies)")
+
+        header = f"  {'Strategy':<50s} {'PROVE':>8s} {'DePROVE':>8s} {'Delta':>8s} {'Chi2':>8s} {'Sig?':>5s} {'N':>5s}"
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for s in strategies:
+            strat = s.get("strategy", "?")[:48]
+            prove = s.get("prove_acc", 0)
+            deprove = s.get("deprove_acc", 0)
+            delta = prove - deprove
+            chi2 = s.get("chi2", 0)
+            sig = "Yes" if chi2 > 3.84 else "No"
+            n = s.get("n_samples", 0)
+            print(f"  {strat:<50s} {fmt_pct(prove)} {fmt_pct(deprove)} {fmt_pct(delta)} {chi2:>8.3f} {sig:>5s} {n:>5d}")
+
+
+# ============================================================================
+# 4. Combined
+# ============================================================================
+
+def print_combined():
+    section("4. v3_combined RESULTS (3645 configs, score + threshold sweep)")
+
+    files = [
+        (BASE / "v3_combined" / "maverick_results.json", "Maverick"),
+        (BASE / "v3_combined" / "llama_results.json", "Llama 3.3 70B"),
+        (BASE / "v3_combined" / "nova_pro_cot_results.json", "Nova Pro CoT"),
+    ]
+
+    for path, name in files:
+        data = load_json(path)
+        if data is None:
+            print(f"  [MISSING] {path}")
+            continue
+        a = analyze_configs(data, name)
+        print_config_table(a)
+
+
+# ============================================================================
+# 5. Power entity
+# ============================================================================
+
+def print_power_entity():
+    section("5. v3_power_entity RESULTS (4800 configs, power-scaled + entity filtering)")
+
+    files = [
+        (BASE / "v3_power_entity" / "maverick_results.json", "Maverick"),
+        (BASE / "v3_power_entity" / "llama_results.json", "Llama 3.3 70B"),
+        (BASE / "v3_power_entity" / "nova_pro_cot_results.json", "Nova Pro CoT"),
+    ]
+
+    for path, name in files:
+        data = load_json(path)
+        if data is None:
+            print(f"  [MISSING] {path}")
+            continue
+        a = analyze_configs(data, name)
+        print_config_table(a)
+
+
+# ============================================================================
+# Grand summary
+# ============================================================================
+
+def print_grand_summary():
+    section("GRAND SUMMARY: Best Results Across All Experiments")
+
+    print()
+    print("  Collecting best PROVE > DePROVE configs across all experiments...")
+    print()
+
+    all_best = []
+
+    # Baselines
+    baselines = [
+        (BASE / "v3_baseline_maverick" / "all_results.json", "Baseline/Maverick"),
+        (BASE / "v3_baseline_llama" / "all_results.json", "Baseline/Llama"),
+        (BASE / "nova_pro_cot" / "all_results.json", "Baseline/NovaPro"),
+    ]
+    for path, name in baselines:
+        data = load_json(path)
+        if data is None:
+            continue
+        r = compute_baseline(data, name)
+        all_best.append({
+            "experiment": name,
+            "config": "(default threshold=0.5)",
+            "prove_acc": r["prove_acc"],
+            "deprove_acc": r["deprove_acc"],
+            "delta": r["delta"],
+            "chi2": r["chi2"],
+            "n": r["n_valid"],
+        })
+
+    # Config-based experiments
+    config_files = [
+        (BASE / "v3_combined" / "maverick_results.json", "Combined/Maverick"),
+        (BASE / "v3_combined" / "llama_results.json", "Combined/Llama"),
+        (BASE / "v3_combined" / "nova_pro_cot_results.json", "Combined/NovaPro"),
+        (BASE / "v3_power_entity" / "maverick_results.json", "PowerEntity/Maverick"),
+        (BASE / "v3_power_entity" / "llama_results.json", "PowerEntity/Llama"),
+        (BASE / "v3_power_entity" / "nova_pro_cot_results.json", "PowerEntity/NovaPro"),
+    ]
+    for path, exp_name in config_files:
+        data = load_json(path)
+        if data is None:
+            continue
+        configs = data.get("configurations", {})
+        # Find best by delta where delta > 0
+        best_delta = None
+        best_chi2 = None
+        for key, c in configs.items():
+            prove = c.get("prove_acc", 0)
+            deprove = c.get("deprove_acc", 0)
+            delta = prove - deprove
+            chi2 = c.get("chi2", 0)
+            n = c.get("n_samples", 0)
+
+            if delta > 0:
+                if best_delta is None or delta > best_delta["delta"]:
+                    best_delta = {"config": key, "prove_acc": prove, "deprove_acc": deprove, "delta": delta, "chi2": chi2, "n": n}
+                if chi2 > 3.84 and (best_chi2 is None or chi2 > best_chi2["chi2"]):
+                    best_chi2 = {"config": key, "prove_acc": prove, "deprove_acc": deprove, "delta": delta, "chi2": chi2, "n": n}
+
+        if best_delta:
+            all_best.append({"experiment": exp_name + " (best gap)", **best_delta})
+        if best_chi2:
+            all_best.append({"experiment": exp_name + " (best chi2)", **best_chi2})
+
+    # Threshold sweep best
+    sweep_files = [
+        (BASE / "v3_threshold_sweep" / "maverick_results.json", "ThreshSweep/Maverick"),
+        (BASE / "v3_threshold_sweep" / "llama_results.json", "ThreshSweep/Llama"),
+    ]
+    for path, exp_name in sweep_files:
+        data = load_json(path)
+        if data is None:
+            continue
+        thresholds = data.get("thresholds", [])
+        best = None
+        for t in thresholds:
+            prove = t.get("prove_acc", 0)
+            deprove = t.get("deprove_acc", 0)
+            delta = prove - deprove
+            chi2 = t.get("chi2", 0)
+            thr = t.get("threshold", t.get("prove_threshold", "?"))
+            n = t.get("n_samples", 0)
+            if delta > 0 and (best is None or delta > best["delta"]):
+                best = {"config": f"t={thr}", "prove_acc": prove, "deprove_acc": deprove, "delta": delta, "chi2": chi2, "n": n}
+        if best:
+            all_best.append({"experiment": exp_name, **best})
+
+    # Sort by delta
+    all_best.sort(key=lambda x: x.get("delta", 0) or 0, reverse=True)
+
+    header = f"  {'Experiment':<35s} {'Config':<45s} {'PROVE':>7s} {'DePROVE':>8s} {'Delta':>7s} {'Chi2':>8s} {'Sig':>4s} {'N':>5s}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for r in all_best[:20]:
+        sig = "*" if r.get("chi2", 0) > 3.84 else ""
+        config = r.get("config", "")[:43]
+        print(f"  {r['experiment']:<35s} {config:<45s} {fmt_pct(r['prove_acc'])} {fmt_pct(r['deprove_acc'])} {fmt_pct(r.get('delta'))} {r.get('chi2',0):>8.3f} {sig:>4s} {r.get('n',0):>5d}")
+
+    print()
+    print("  * = statistically significant (McNemar chi2 > 3.84, p < 0.05)")
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    print(hline(120, "="))
+    print("  PROVE PROJECT -- COMPREHENSIVE EXPERIMENT RESULTS")
+    print(f"  Generated: {__import__('datetime').datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(hline(120, "="))
+
+    print_baselines()
+    print_threshold_sweep()
+    print_dynamic_threshold()
+    print_combined()
+    print_power_entity()
+    print_grand_summary()
+
+    print()
+    print(hline(120, "="))
+    print("  END OF RESULTS")
+    print(hline(120, "="))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/problog_utils.py
+++ b/src/eval/problog_utils.py
@@ -1,0 +1,195 @@
+"""
+Shared ProbLog helpers for post-hoc evaluation.
+
+Provides: SemiringDampened, quote_arg, build_score_lookups, get_score,
+          rebuild_facts, execute_problog_direct.
+"""
+
+from problog.program import PrologString
+from problog import get_evaluatable
+from problog.evaluator import Semiring
+
+
+# ─── Semirings ───────────────────────────────────────────────────────────────
+
+class SemiringDampened(Semiring):
+    """Dampened semiring: raises AND/OR combinations to alpha power.
+
+    When alpha < 1, this prevents probabilities from shrinking too fast
+    when many facts are chained together via AND.
+    alpha=1.0 is equivalent to standard ProbLog.
+    """
+    def __init__(self, alpha=0.8):
+        Semiring.__init__(self)
+        self.alpha = alpha
+
+    def one(self): return 1.0
+    def zero(self): return 0.0
+    def is_one(self, v): return v == 1.0
+    def is_zero(self, v): return v == 0.0
+    def plus(self, a, b): return 1.0 - (max(0, (1-a)*(1-b)))**self.alpha
+    def times(self, a, b): return (max(0, a*b))**self.alpha
+    def negate(self, a): return 1.0 - a
+    def value(self, a): return float(a)
+    def normalize(self, a, z): return a
+    def result(self, a, formula=None): return float(a)
+    def ad_negate(self, s, pos_only): return self.negate(s)
+    def true(self, a=None): return 1.0
+    def false(self, a=None): return 0.0
+    def is_nsp(self): return True
+    def pos_value(self, a, key=None): return float(a)
+    def neg_value(self, a, key=None): return 1.0 - float(a)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def quote_arg(arg):
+    """Quote a ProbLog argument for safe embedding in a program string."""
+    if not isinstance(arg, str):
+        return str(arg)
+    if "'" in arg or " " in arg or "-" in arg or (arg and arg[0].isupper()):
+        escaped = str(arg).replace("'", "\\'")
+        return f"'{escaped}'"
+    return arg
+
+
+def build_score_lookups(sample):
+    """Build lookup dicts from a sample's evidence for fast score retrieval."""
+    attr_lookup = {}
+    for attr in sample.get('evidence', {}).get('attributes', []):
+        key = (attr.get('entity_id'), attr.get('value'))
+        attr_lookup[key] = attr
+    rel_lookup = {}
+    for rel in sample.get('evidence', {}).get('relationships', []):
+        key = (rel.get('subject_id'), rel.get('object_id'), rel.get('relation'))
+        rel_lookup[key] = rel
+    return attr_lookup, rel_lookup
+
+
+def get_score(ev, score_type):
+    """Get a score from an evidence dict, with support for averaged scores."""
+    if score_type == 'avg_blip_qwen_tf':
+        b = ev.get('blip_score')
+        q = ev.get('qwen_tf_score')
+        if b is not None and q is not None:
+            return (b + q) / 2.0
+        return b if b is not None else q
+    else:
+        return ev.get(score_type)
+
+
+# ─── Fact building ───────────────────────────────────────────────────────────
+
+def rebuild_facts(sample, attr_score_type, rel_score_type, entity_prob=None, agreement_mode=None):
+    """
+    Rebuild ProbLog facts with separate score types for attributes and relations.
+
+    agreement_mode:
+        None          - no adjustment
+        'dampen_0.5'  - disagree: pull toward 0.5 by 50%
+        'dampen_0.3'  - disagree: pull toward 0.5 by 70%
+        'sharpen'     - agree: push away from 0.5 by 50% (factor 1.5)
+        'both'        - disagree: dampen 0.5, agree: sharpen 1.5
+    """
+    stored_facts = sample.get('problog', {}).get('facts', [])
+    if not stored_facts:
+        return None
+
+    attr_lookup, rel_lookup = build_score_lookups(sample)
+    new_facts = []
+
+    # Parse agreement mode into dampen/sharpen factors
+    dampen_factor = None
+    sharpen_factor = None
+    if agreement_mode == 'dampen_0.5':
+        dampen_factor = 0.5
+    elif agreement_mode == 'dampen_0.3':
+        dampen_factor = 0.3
+    elif agreement_mode == 'sharpen':
+        sharpen_factor = 1.5
+    elif agreement_mode == 'both':
+        dampen_factor = 0.5
+        sharpen_factor = 1.5
+
+    for fact in stored_facts:
+        pred = fact.get('predicate', '')
+        args = fact.get('arguments', [])
+        prob = fact.get('probability', 0.5)
+
+        if pred == 'entity':
+            if entity_prob is not None:
+                prob = entity_prob
+
+        elif pred == 'attribute' and len(args) >= 3:
+            key = (args[1], args[2])
+            ev = attr_lookup.get(key)
+            if ev:
+                raw = get_score(ev, attr_score_type)
+                if raw is not None:
+                    prob = raw
+                if dampen_factor is not None or sharpen_factor is not None:
+                    blip = ev.get('blip_score')
+                    qwen = ev.get('qwen_tf_score')
+                    if blip is not None and qwen is not None:
+                        disagree = (blip >= 0.5) != (qwen >= 0.5)
+                        if disagree and dampen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * dampen_factor
+                        elif not disagree and sharpen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * sharpen_factor
+
+        elif pred == 'relation' and len(args) >= 4:
+            key = (args[1], args[2], args[3])
+            ev = rel_lookup.get(key)
+            if ev:
+                raw = get_score(ev, rel_score_type)
+                if raw is not None:
+                    prob = raw
+                if dampen_factor is not None or sharpen_factor is not None:
+                    blip = ev.get('blip_score')
+                    qwen = ev.get('qwen_tf_score')
+                    if blip is not None and qwen is not None:
+                        disagree = (blip >= 0.5) != (qwen >= 0.5)
+                        if disagree and dampen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * dampen_factor
+                        elif not disagree and sharpen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * sharpen_factor
+
+        new_facts.append({**fact, 'probability': max(1e-7, min(1 - 1e-7, prob))})
+    return new_facts
+
+
+# ─── Threshold ───────────────────────────────────────────────────────────────
+
+def threshold_fn(n_facts, base, slope):
+    """Log-based dynamic threshold: clip(base + slope * ln(n_facts + 1), 0, 1)."""
+    import math
+    return max(0.0, min(1.0, base + slope * math.log(n_facts + 1)))
+
+
+# ─── ProbLog execution ───────────────────────────────────────────────────────
+
+def execute_problog_direct(facts, rules, query, semiring=None):
+    """Run ProbLog directly (no timeout). Used inside worker subprocesses."""
+    lines = []
+    for f in facts:
+        args_str = ", ".join(quote_arg(a) for a in f['arguments'])
+        p = max(1e-7, min(1 - 1e-7, f['probability']))
+        lines.append(f"{p}::{f['predicate']}({args_str}).")
+    program_str = "\n".join(lines) + f"\n\n{rules}\n\n{query}"
+    try:
+        if semiring is not None:
+            kc_class = get_evaluatable(semiring=semiring)
+            program = PrologString(program_str)
+            kc = kc_class.create_from(program, semiring=semiring)
+            result = kc.evaluate(semiring=semiring)
+        else:
+            program = PrologString(program_str)
+            result = get_evaluatable().create_from(program).evaluate()
+        for atom, prob in result.items():
+            if 'answer' in str(atom):
+                return float(prob)
+        return 0.0
+    except TimeoutError:
+        raise
+    except:
+        return None

--- a/src/eval/quick_acc_check.py
+++ b/src/eval/quick_acc_check.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+Quick accuracy check using the optimized v5 per-LLM config.
+Standalone — only imports problog, json, math (no src.*).
+Uses multiprocessing with per-sample timeouts to avoid hangs.
+"""
+
+import json
+import math
+import sys
+import os
+import time
+import multiprocessing as mp
+from collections import defaultdict
+
+from problog.program import PrologString
+from problog import get_evaluatable
+from problog.evaluator import Semiring
+
+
+# ─── Config (loaded from configs.json) ─────────────────────────────────────
+
+_CONFIGS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "configs.json")
+with open(_CONFIGS_PATH) as _f:
+    _ALL_CONFIGS = json.load(_f)
+
+import argparse
+_parser = argparse.ArgumentParser(description="Quick accuracy check with optimized config")
+_parser.add_argument('base_dir', nargs='?', default='/home/huan2073/PROVE', help='Project root')
+_parser.add_argument('dataset', nargs='?', default='vqav2', help='Dataset name')
+_parser.add_argument('version', nargs='?', default='v5', help='Version prefix')
+_parser.add_argument('--config', default='v5_perlm', choices=list(_ALL_CONFIGS.keys()),
+                     help='Scoring config preset (default: v5_perlm)')
+_args = _parser.parse_args()
+
+_preset = _ALL_CONFIGS[_args.config]
+LLM_CONFIGS = {}
+for _llm, _cfg in _preset['llm_configs'].items():
+    LLM_CONFIGS[_llm] = {
+        'attr_score': _cfg['attr_score_type'],
+        'rel_score': _cfg['rel_score_type'],
+        'entity_prob': _cfg['entity_prob'],
+        'dampening': _cfg['dampened_alpha'],
+        'agreement': _cfg['agreement_mode'],
+    }
+
+THRESHOLD_BASE = _preset['threshold']['base']
+THRESHOLD_SLOPE = _preset['threshold']['slope']
+
+BASE_DIR = _args.base_dir
+DATASET = _args.dataset
+VERSION = _args.version
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+def quote_arg(arg):
+    if not isinstance(arg, str):
+        return str(arg)
+    if "'" in arg or " " in arg or "-" in arg or (arg and arg[0].isupper()):
+        escaped = str(arg).replace("'", "\\'")
+        return f"'{escaped}'"
+    return arg
+
+
+def get_score(ev, score_type):
+    if score_type == 'avg_blip_qwen_tf':
+        b = ev.get('blip_score')
+        q = ev.get('qwen_tf_score')
+        if b is not None and q is not None:
+            return (b + q) / 2.0
+        return b if b is not None else q
+    return ev.get(score_type)
+
+
+def build_score_lookups(sample):
+    attr_lookup = {}
+    for attr in sample.get('evidence', {}).get('attributes', []):
+        key = (attr.get('entity_id'), attr.get('value'))
+        attr_lookup[key] = attr
+    rel_lookup = {}
+    for rel in sample.get('evidence', {}).get('relationships', []):
+        key = (rel.get('subject_id'), rel.get('object_id'), rel.get('relation'))
+        rel_lookup[key] = rel
+    return attr_lookup, rel_lookup
+
+
+def rebuild_facts(sample, attr_score_type, rel_score_type, entity_prob=None, agreement_mode=None):
+    stored_facts = sample.get('problog', {}).get('facts', [])
+    if not stored_facts:
+        return None
+
+    attr_lookup, rel_lookup = build_score_lookups(sample)
+    new_facts = []
+
+    dampen_factor = sharpen_factor = None
+    if agreement_mode == 'dampen_0.5': dampen_factor = 0.5
+    elif agreement_mode == 'dampen_0.3': dampen_factor = 0.3
+    elif agreement_mode == 'sharpen': sharpen_factor = 1.5
+    elif agreement_mode == 'both': dampen_factor, sharpen_factor = 0.5, 1.5
+
+    for fact in stored_facts:
+        pred = fact.get('predicate', '')
+        args = fact.get('arguments', [])
+        prob = fact.get('probability', 0.5)
+
+        if pred == 'entity':
+            if entity_prob is not None:
+                prob = entity_prob
+        elif pred == 'attribute' and len(args) >= 3:
+            ev = attr_lookup.get((args[1], args[2]))
+            if ev:
+                raw = get_score(ev, attr_score_type)
+                if raw is not None: prob = raw
+                if dampen_factor is not None or sharpen_factor is not None:
+                    blip, qwen = ev.get('blip_score'), ev.get('qwen_tf_score')
+                    if blip is not None and qwen is not None:
+                        disagree = (blip >= 0.5) != (qwen >= 0.5)
+                        if disagree and dampen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * dampen_factor
+                        elif not disagree and sharpen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * sharpen_factor
+        elif pred == 'relation' and len(args) >= 4:
+            ev = rel_lookup.get((args[1], args[2], args[3]))
+            if ev:
+                raw = get_score(ev, rel_score_type)
+                if raw is not None: prob = raw
+                if dampen_factor is not None or sharpen_factor is not None:
+                    blip, qwen = ev.get('blip_score'), ev.get('qwen_tf_score')
+                    if blip is not None and qwen is not None:
+                        disagree = (blip >= 0.5) != (qwen >= 0.5)
+                        if disagree and dampen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * dampen_factor
+                        elif not disagree and sharpen_factor is not None:
+                            prob = 0.5 + (prob - 0.5) * sharpen_factor
+
+        new_facts.append({**fact, 'probability': max(1e-7, min(1 - 1e-7, prob))})
+    return new_facts
+
+
+def execute_problog_direct(facts, rules, query, semiring=None):
+    lines = []
+    for f in facts:
+        args_str = ", ".join(quote_arg(a) for a in f['arguments'])
+        p = max(1e-7, min(1 - 1e-7, f['probability']))
+        lines.append(f"{p}::{f['predicate']}({args_str}).")
+    program_str = "\n".join(lines) + f"\n\n{rules}\n\n{query}"
+    try:
+        if semiring is not None:
+            kc_class = get_evaluatable(semiring=semiring)
+            program = PrologString(program_str)
+            kc = kc_class.create_from(program, semiring=semiring)
+            result = kc.evaluate(semiring=semiring)
+        else:
+            result = get_evaluatable().create_from(PrologString(program_str)).evaluate()
+        for atom, prob in result.items():
+            if 'answer' in str(atom):
+                return float(prob)
+        return 0.0
+    except:
+        return None
+
+
+def to_bool_label(label):
+    if isinstance(label, bool): return label
+    if isinstance(label, str): return label.lower() in ('true', 'yes', '1')
+    return bool(label)
+
+
+# ─── Dampened semiring ─────────────────────────────────────────────────────
+
+class SemiringDampened(Semiring):
+    def __init__(self, alpha=0.8):
+        Semiring.__init__(self)
+        self.alpha = alpha
+    def one(self): return 1.0
+    def zero(self): return 0.0
+    def is_one(self, v): return v == 1.0
+    def is_zero(self, v): return v == 0.0
+    def plus(self, a, b): return 1.0 - (max(0, (1-a)*(1-b)))**self.alpha
+    def times(self, a, b): return (max(0, a*b))**self.alpha
+    def negate(self, a): return 1.0 - a
+    def value(self, a): return float(a)
+    def normalize(self, a, z): return a
+    def result(self, a, formula=None): return float(a)
+    def ad_negate(self, s, pos_only): return self.negate(s)
+    def true(self, a=None): return 1.0
+    def false(self, a=None): return 0.0
+    def is_nsp(self): return True
+    def pos_value(self, a, key=None): return float(a)
+    def neg_value(self, a, key=None): return 1.0 - float(a)
+
+
+# ─── Parallel worker ──────────────────────────────────────────────────────
+
+def _worker(batch, result_queue, worker_id):
+    """Process batch of (ident, facts, rules, query, da) tuples."""
+    for item in batch:
+        ident, facts, rules, query, da = item
+        sr = SemiringDampened(alpha=da) if da != 1.0 else None
+        prove_prob = execute_problog_direct(facts, rules, query, semiring=sr)
+        dep_facts = [{**f, 'probability': 1.0 if f['probability'] >= 0.5 else 0.0} for f in facts]
+        dep_prob = execute_problog_direct(dep_facts, rules, query, semiring=None)
+        result_queue.put((worker_id, ident, prove_prob, dep_prob, len(facts)))
+
+
+def run_parallel(work_items, n_workers=30, batch_size=40, timeout_per_item=15):
+    """Run ProbLog evaluations in parallel with timeout protection."""
+    result_queue = mp.Queue()
+    active = {}
+    results = {}
+    next_wid = [0]
+    completed_by_worker = defaultdict(set)
+
+    def drain():
+        while not result_queue.empty():
+            try:
+                wid, ident, pp, dp, nf = result_queue.get_nowait()
+                completed_by_worker[wid].add(ident)
+                results[ident] = (pp, dp, nf)
+            except:
+                break
+
+    def reap():
+        for pid in list(active):
+            proc, deadline, wid, bidents = active[pid]
+            if not proc.is_alive():
+                proc.join(timeout=1)
+                del active[pid]
+
+    def kill_expired():
+        now = time.time()
+        for pid in list(active):
+            proc, deadline, wid, bidents = active[pid]
+            if now > deadline:
+                proc.kill()
+                proc.join(timeout=5)
+                drain()
+                completed = completed_by_worker.get(wid, set())
+                skipped = [i for i in bidents if i not in completed]
+                if skipped:
+                    print(f"    TIMEOUT: killed worker, skipped {len(skipped)} items (first: {skipped[0]})")
+                del active[pid]
+
+    batch = []
+    for item in work_items:
+        batch.append(item)
+        if len(batch) >= batch_size:
+            while len(active) >= n_workers:
+                drain(); reap(); kill_expired()
+                if len(active) >= n_workers: time.sleep(0.05)
+            wid = next_wid[0]; next_wid[0] += 1
+            bidents = [it[0] for it in batch]
+            deadline = time.time() + len(batch) * 1.0 + timeout_per_item
+            p = mp.Process(target=_worker, args=(batch, result_queue, wid))
+            p.start()
+            active[p.pid] = (p, deadline, wid, bidents)
+            batch = []
+            drain()
+
+    if batch:
+        while len(active) >= n_workers:
+            drain(); reap(); kill_expired()
+            if len(active) >= n_workers: time.sleep(0.05)
+        wid = next_wid[0]; next_wid[0] += 1
+        bidents = [it[0] for it in batch]
+        deadline = time.time() + len(batch) * 1.0 + timeout_per_item
+        p = mp.Process(target=_worker, args=(batch, result_queue, wid))
+        p.start()
+        active[p.pid] = (p, deadline, wid, bidents)
+
+    while active:
+        drain(); reap(); kill_expired()
+        if active: time.sleep(0.1)
+    drain()
+    return results
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────
+
+def main():
+    # Load data
+    llm_data = {}
+    for llm in LLM_CONFIGS:
+        path = os.path.join(BASE_DIR, 'eval', f'{VERSION}_{DATASET}_{llm}', 'all_results.json')
+        if not os.path.exists(path):
+            print(f"  {llm}: not found at {path}")
+            continue
+        with open(path) as f:
+            data = json.load(f)
+        idx = {}
+        for s in data:
+            ident = s.get('identifier')
+            if ident and s.get('success', False) and s.get('label') is not None:
+                idx[ident] = s
+        llm_data[llm] = idx
+        print(f"  {llm}: {len(idx)} successful samples")
+
+    if not llm_data:
+        print("No data!"); return
+
+    all_idents = set()
+    for idx in llm_data.values():
+        all_idents |= set(idx.keys())
+    common = set.intersection(*[set(idx.keys()) for idx in llm_data.values()])
+    print(f"\nUnion: {len(all_idents)}, Common: {len(common)}")
+
+    # ── Phase 1: per-LLM evaluation (parallel) ────────────────────────────
+    print(f"\n{'='*60}")
+    print("Phase 1: Per-LLM ProbLog evaluation (parallel)")
+    print(f"{'='*60}")
+
+    # key = (llm, ident), value = (prove_prob, dep_prob, n_facts)
+    all_results = {}
+
+    for llm, cfg in LLM_CONFIGS.items():
+        if llm not in llm_data:
+            continue
+        idx = llm_data[llm]
+        print(f"\n  {llm}: building {len(idx)} work items...")
+
+        work_items = []
+        for ident in idx:
+            sample = idx[ident]
+            facts = rebuild_facts(sample, cfg['attr_score'], cfg['rel_score'],
+                                  entity_prob=cfg['entity_prob'], agreement_mode=cfg['agreement'])
+            if facts is None: continue
+            rules = sample.get('problog', {}).get('rules', '')
+            query = sample.get('problog', {}).get('query', '')
+            if not rules or not query: continue
+            work_items.append((ident, facts, rules, query, cfg['dampening']))
+
+        print(f"  {llm}: running {len(work_items)} through ProbLog...")
+        t0 = time.time()
+        results = run_parallel(work_items)
+        elapsed = time.time() - t0
+        print(f"  {llm}: done in {elapsed:.1f}s ({len(results)} results)")
+
+        for ident, (pp, dp, nf) in results.items():
+            all_results[(llm, ident)] = (pp, dp, nf)
+
+    # ── Phase 2: compute accuracy ─────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print("Phase 2: Accuracy with v5 optimized config")
+    print(f"Threshold: log(b={THRESHOLD_BASE}, s={THRESHOLD_SLOPE})")
+    print(f"{'='*60}")
+
+    # Per-LLM
+    for llm in LLM_CONFIGS:
+        if llm not in llm_data: continue
+        idx = llm_data[llm]
+        n_prove = n_dep = n_eval = 0
+
+        for ident in idx:
+            label = to_bool_label(idx[ident]['label'])
+            key = (llm, ident)
+            if key not in all_results: continue
+            pp, dp, nf = all_results[key]
+            if pp is None and dp is None: continue
+            n_eval += 1
+
+            threshold = max(0, min(1, THRESHOLD_BASE + THRESHOLD_SLOPE * math.log(nf + 1)))
+            if (pp is not None and (pp >= threshold) == label):
+                n_prove += 1
+            elif pp is None and not label:
+                n_prove += 1  # None → predict False
+
+            if dp is not None and ((dp >= 0.5) == label):
+                n_dep += 1
+
+        print(f"\n  {llm} ({n_eval} evaluated):")
+        if n_eval:
+            print(f"    PROVE:   {n_prove}/{n_eval} = {n_prove/n_eval*100:.2f}%")
+            print(f"    DePROVE: {n_dep}/{n_eval} = {n_dep/n_eval*100:.2f}%")
+
+    # Ensemble on union
+    n_total = len(all_idents)
+    n_prove_ens = n_dep_ens = 0
+
+    for ident in all_idents:
+        label = None
+        for idx in llm_data.values():
+            if ident in idx:
+                label = to_bool_label(idx[ident]['label'])
+                break
+
+        prove_probs = []
+        dep_preds = []
+        nfacts_list = []
+
+        for llm in LLM_CONFIGS:
+            key = (llm, ident)
+            if key in all_results:
+                pp, dp, nf = all_results[key]
+                if pp is not None:
+                    prove_probs.append(pp)
+                    nfacts_list.append(nf)
+                dep_preds.append((dp >= 0.5) if dp is not None else False)
+            else:
+                dep_preds.append(False)
+
+        # PROVE perlm_soft
+        if prove_probs:
+            avg_p = sum(prove_probs) / len(prove_probs)
+            avg_nf = sum(nfacts_list) / len(nfacts_list)
+            thr = max(0, min(1, THRESHOLD_BASE + THRESHOLD_SLOPE * math.log(avg_nf + 1)))
+            if (avg_p >= thr) == label:
+                n_prove_ens += 1
+        else:
+            if not label:  # all missing → predict False
+                n_prove_ens += 1
+
+        # DePROVE majority
+        n_true = sum(1 for p in dep_preds if p)
+        if (n_true > len(dep_preds) / 2) == label:
+            n_dep_ens += 1
+
+    print(f"\n  ENSEMBLE (n={n_total}, union):")
+    print(f"    PROVE perlm_soft: {n_prove_ens}/{n_total} = {n_prove_ens/n_total*100:.2f}%")
+    print(f"    DePROVE majority: {n_dep_ens}/{n_total} = {n_dep_ens/n_total*100:.2f}%")
+
+    # Ensemble on common
+    n_common = len(common)
+    n_prove_com = n_dep_com = 0
+
+    for ident in common:
+        label = to_bool_label(list(llm_data.values())[0][ident]['label'])
+
+        prove_probs = []
+        dep_preds = []
+        nfacts_list = []
+
+        for llm in LLM_CONFIGS:
+            key = (llm, ident)
+            if key in all_results:
+                pp, dp, nf = all_results[key]
+                if pp is not None:
+                    prove_probs.append(pp)
+                    nfacts_list.append(nf)
+                dep_preds.append((dp >= 0.5) if dp is not None else False)
+            else:
+                dep_preds.append(False)
+
+        if prove_probs:
+            avg_p = sum(prove_probs) / len(prove_probs)
+            avg_nf = sum(nfacts_list) / len(nfacts_list)
+            thr = max(0, min(1, THRESHOLD_BASE + THRESHOLD_SLOPE * math.log(avg_nf + 1)))
+            if (avg_p >= thr) == label:
+                n_prove_com += 1
+        else:
+            if not label:
+                n_prove_com += 1
+
+        n_true = sum(1 for p in dep_preds if p)
+        if (n_true > len(dep_preds) / 2) == label:
+            n_dep_com += 1
+
+    print(f"\n  COMMON SUBSET (n={n_common}):")
+    print(f"    PROVE perlm_soft: {n_prove_com}/{n_common} = {n_prove_com/n_common*100:.2f}%")
+    print(f"    DePROVE majority: {n_dep_com}/{n_common} = {n_dep_com/n_common*100:.2f}%")
+
+    print(f"\nDone!")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/eval/run_eval.py
+++ b/src/eval/run_eval.py
@@ -1,0 +1,912 @@
+#!/usr/bin/env python3
+"""
+Comprehensive PROVE evaluation with dual-model scoring.
+
+Runs the new pipeline on NLVR2 balanced test set, collecting BOTH
+BLIP-ITM and Qwen logit-based scores for every verification action.
+Saves all intermediate data for post-hoc experiments.
+"""
+
+import os
+import sys
+import json
+import gc
+import time
+import argparse
+import traceback
+import torch
+from pathlib import Path
+from PIL import Image
+from tqdm import tqdm
+
+# Add project root (two levels up from src/eval/) to sys.path
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, _PROJECT_ROOT)
+
+from src.core.model_manager import ModelManager
+from src.core.knowledge_base import KnowledgeBase
+from src.pipeline.detector import Detector
+from src.pipeline.unified_agent import UnifiedAgent
+from src.pipeline.problog_executor import ProbLogExecutor
+from src.pipeline.problog_builder import ProbLogFactBuilder
+from src.vision.qwen_verifier import QwenVerifier
+from src.vision.blip_verifier import BLIPVerifier
+
+# ── LLM model registry ──────────────────────────────────────────────────────
+LLM_MODELS = {
+    "llama":          "us.meta.llama3-3-70b-instruct-v1:0",
+    "maverick":       "us.meta.llama4-maverick-17b-instruct-v1:0",
+    "mistral_large":  "mistral.mistral-large-3-675b-instruct",
+    "nova_pro":       "us.amazon.nova-pro-v1:0",
+    "nova_premier":   "us.amazon.nova-premier-v1:0",
+    "sonnet":         "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+}
+
+# ── Dataset presets ──────────────────────────────────────────────────────────
+DATASET_PRESETS = {
+    "test1": {
+        "type": "nlvr2",
+        "test_json": "nlvr2_data/balanced_test1.json",
+        "img_dir":   "nlvr2_data/images",
+        "z_filter":  0,
+    },
+    "test2": {
+        "type": "nlvr2",
+        "test_json": "nlvr2_data/balanced_test2.json",
+        "img_dir":   "nlvr2_data/images",
+        "z_filter":  0,
+    },
+    "gqa": {
+        "type": "gqa",
+        "test_json": "gqa_data/testdev_balanced_yn.json",
+        "img_dir":   "gqa_data/images",
+        "z_filter":  None,
+    },
+    "vqav2": {
+        "type": "gqa",
+        "test_json": "vqav2_data/val_balanced_yn.json",
+        "img_dir":   "vqav2_data/images",
+        "z_filter":  None,
+    },
+}
+
+# ── Scoring configs (loaded from configs.json) ──────────────────────────
+_CONFIGS_PATH = os.path.join(os.path.dirname(__file__), "configs.json")
+with open(_CONFIGS_PATH) as _f:
+    _ALL_CONFIGS = json.load(_f)
+
+
+def nlvr2_id_to_image_paths(identifier, img_dir, directory=None):
+    """Map NLVR2 identifier to image file paths.
+
+    identifier format: "test1-X-Y-Z" → images "test1-X-Y-img0.png" and "test1-X-Y-img1.png"
+    Also checks nested train directory structure: images/train/{directory}/train-X-Y-img0.png
+    """
+    parts = identifier.rsplit("-", 1)
+    img_base = parts[0]
+    img_a = os.path.join(img_dir, f"{img_base}-img0.png")
+    img_b = os.path.join(img_dir, f"{img_base}-img1.png")
+
+    # If flat paths don't exist, check nested directory structure (train data)
+    if not os.path.exists(img_a) and directory is not None:
+        split = identifier.split("-")[0]  # "train", "test1", "dev"
+        nested_a = os.path.join(img_dir, "images", split, str(directory), f"{img_base}-img0.png")
+        nested_b = os.path.join(img_dir, "images", split, str(directory), f"{img_base}-img1.png")
+        if os.path.exists(nested_a):
+            return nested_a, nested_b
+
+    return img_a, img_b
+
+
+def load_gqa_samples(json_path, img_dir):
+    """Load GQA dataset samples.
+
+    GQA format: dict of {question_id: {question, imageId, answer, ...}}
+    Returns list of dicts with unified keys matching NLVR2 format.
+    """
+    with open(json_path) as f:
+        data = json.load(f)
+
+    samples = []
+    for qid, entry in data.items():
+        image_id = entry["imageId"]
+        answer = entry["answer"].lower()
+        # Map yes/no to True/False for consistency with NLVR2
+        label = answer == "yes"
+
+        # Try .jpg first, then .png
+        img_path = os.path.join(img_dir, f"{image_id}.jpg")
+        if not os.path.exists(img_path):
+            img_path = os.path.join(img_dir, f"{image_id}.png")
+
+        samples.append({
+            "identifier": qid,
+            "sentence": entry["question"],
+            "label": label,
+            "image_path": img_path,
+            "gqa_answer": answer,
+        })
+
+    return samples
+
+
+
+def _eval_sample_worker(args_tuple):
+    """Worker function for parallel post-hoc ProbLog evaluation (picklable)."""
+    from src.eval.problog_utils import rebuild_facts, execute_problog_direct, SemiringDampened
+
+    llm, ident, sample, cfg = args_tuple
+    facts = rebuild_facts(sample, cfg['attr_score_type'], cfg['rel_score_type'],
+                          entity_prob=cfg['entity_prob'], agreement_mode=cfg['agreement_mode'])
+    rules = sample.get('problog', {}).get('rules', '')
+    query = sample.get('problog', {}).get('query', '')
+
+    if facts is None or not rules or not query:
+        return llm, ident, None, None, 0
+
+    da = cfg['dampened_alpha']
+    sr = SemiringDampened(alpha=da) if da != 1.0 else None
+    prove_prob = execute_problog_direct(facts, rules, query, semiring=sr)
+
+    dep_facts = [{**f, 'probability': 1.0 if f['probability'] >= 0.5 else 0.0} for f in facts]
+    dep_prob = execute_problog_direct(dep_facts, rules, query, semiring=None)
+
+    return llm, ident, prove_prob, dep_prob, len(facts)
+
+
+def run_multi_llm(args):
+    """Orchestrate parallel data collection for multiple LLMs, then evaluate ensemble."""
+    import subprocess as sp
+
+    llm_list = args.llm
+    n_gpus = torch.cuda.device_count() if torch.cuda.is_available() else 1
+    print(f"\nMulti-LLM mode: {len(llm_list)} LLMs, {n_gpus} GPU(s) available")
+
+    # Check which LLMs already have complete results
+    to_run = []
+    for llm in llm_list:
+        output_dir = f"eval/{args.version}_{args.dataset}_{llm}"
+        result_file = os.path.join(output_dir, "all_results.json")
+        if os.path.exists(result_file):
+            with open(result_file) as f:
+                data = json.load(f)
+            n_success = sum(1 for s in data if s.get('success'))
+            print(f"  {llm}: {n_success} results exist in {output_dir}")
+        else:
+            to_run.append(llm)
+
+    if to_run:
+        print(f"\nLaunching data collection for: {', '.join(to_run)}")
+
+        if n_gpus >= len(to_run):
+            # Parallel: one LLM per GPU
+            processes = []
+            for i, llm in enumerate(to_run):
+                gpu_id = i % n_gpus
+                env = os.environ.copy()
+                env['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
+
+                cmd = [sys.executable, os.path.abspath(__file__),
+                       '--llm', llm,
+                       '--dataset', args.dataset,
+                       '--version', args.version,
+                       '--config', args.config]
+                if args.resume_from:
+                    cmd.extend(['--resume_from', str(args.resume_from)])
+                if args.end_at:
+                    cmd.extend(['--end_at', str(args.end_at)])
+                if args.max_samples:
+                    cmd.extend(['--max_samples', str(args.max_samples)])
+                if args.retry_failed:
+                    cmd.append('--retry_failed')
+                if args.data_root:
+                    cmd.extend(['--data_root', args.data_root])
+                if args.test_json:
+                    cmd.extend(['--test_json', args.test_json])
+                if args.img_dir:
+                    cmd.extend(['--img_dir', args.img_dir])
+
+                print(f"  {llm} → GPU {gpu_id}")
+                p = sp.Popen(cmd, env=env)
+                processes.append((llm, p))
+
+            for llm, p in processes:
+                rc = p.wait()
+                if rc != 0:
+                    print(f"  WARNING: {llm} exited with code {rc}")
+                else:
+                    print(f"  {llm} completed successfully")
+        else:
+            # Sequential: share GPUs (avoids OOM)
+            for llm in to_run:
+                print(f"\n  Running {llm}...")
+                cmd = [sys.executable, os.path.abspath(__file__),
+                       '--llm', llm,
+                       '--dataset', args.dataset,
+                       '--version', args.version,
+                       '--config', args.config]
+                if args.resume_from:
+                    cmd.extend(['--resume_from', str(args.resume_from)])
+                if args.end_at:
+                    cmd.extend(['--end_at', str(args.end_at)])
+                if args.max_samples:
+                    cmd.extend(['--max_samples', str(args.max_samples)])
+                if args.retry_failed:
+                    cmd.append('--retry_failed')
+                if args.data_root:
+                    cmd.extend(['--data_root', args.data_root])
+                if args.test_json:
+                    cmd.extend(['--test_json', args.test_json])
+                if args.img_dir:
+                    cmd.extend(['--img_dir', args.img_dir])
+
+                rc = sp.call(cmd)
+                if rc != 0:
+                    print(f"  WARNING: {llm} exited with code {rc}")
+                else:
+                    print(f"  {llm} completed successfully")
+    else:
+        print("\nAll LLM results already exist. Skipping data collection.")
+
+    # Post-hoc ensemble evaluation with the specified scoring config
+    evaluate_with_config(args)
+
+
+def _parse_per_llm_arg(values):
+    """Parse a nargs='+' arg into (default_value, {llm: override_value}).
+
+    Examples:
+        ['qwen_tf_score']                                → ('qwen_tf_score', {})
+        ['qwen_tf_score', 'maverick=avg_blip_qwen_tf']   → ('qwen_tf_score', {'maverick': 'avg_blip_qwen_tf'})
+        ['maverick=avg_blip_qwen_tf']                     → (None, {'maverick': 'avg_blip_qwen_tf'})
+        ['1.0', 'maverick=0.9', 'mistral_large=0.9']     → ('1.0', {'maverick': '0.9', 'mistral_large': '0.9'})
+    """
+    if values is None:
+        return None, {}
+    default = None
+    overrides = {}
+    for v in values:
+        if '=' in v:
+            llm, val = v.split('=', 1)
+            overrides[llm] = val
+        else:
+            default = v
+    return default, overrides
+
+
+def evaluate_with_config(args):
+    """Apply scoring config to collected results and report ensemble accuracy."""
+    import math
+    import multiprocessing as mp
+
+    llm_list = args.llm if isinstance(args.llm, list) else [args.llm]
+    preset_thresh = _ALL_CONFIGS[args.config]["threshold"]
+    thresh_base = args.thresh_base if args.thresh_base is not None else preset_thresh["base"]
+    thresh_slope = args.thresh_slope if args.thresh_slope is not None else preset_thresh["slope"]
+
+    # Parse per-LLM CLI args once
+    attr_default, attr_overrides = _parse_per_llm_arg(args.attr_score)
+    rel_default, rel_overrides = _parse_per_llm_arg(args.rel_score)
+    ep_default, ep_overrides = _parse_per_llm_arg(args.entity_prob)
+    da_default, da_overrides = _parse_per_llm_arg(args.dampened_alpha)
+    ag_default, ag_overrides = _parse_per_llm_arg(args.agreement)
+
+    def _resolve(default, overrides, llm, cfg_key):
+        """Get the value for an LLM: CLI override > CLI default > per-LLM default (already in cfg)."""
+        if llm in overrides:
+            return overrides[llm]
+        if default is not None:
+            return default
+        return None  # keep existing per-LLM default
+
+    def _build_llm_config(llm):
+        """Build scoring config for an LLM: start with per-LLM defaults, override with CLI args."""
+        preset = _ALL_CONFIGS[args.config]
+        cfg = preset["llm_configs"].get(llm, preset["fallback"]).copy()
+
+        val = _resolve(attr_default, attr_overrides, llm, "attr_score_type")
+        if val is not None:
+            cfg["attr_score_type"] = val
+
+        val = _resolve(rel_default, rel_overrides, llm, "rel_score_type")
+        if val is not None:
+            cfg["rel_score_type"] = val
+
+        val = _resolve(ep_default, ep_overrides, llm, "entity_prob")
+        if val is not None:
+            cfg["entity_prob"] = None if val == "orig" else float(val)
+
+        val = _resolve(da_default, da_overrides, llm, "dampened_alpha")
+        if val is not None:
+            cfg["dampened_alpha"] = float(val)
+
+        val = _resolve(ag_default, ag_overrides, llm, "agreement_mode")
+        if val is not None:
+            cfg["agreement_mode"] = None if val == "none" else val
+
+        return cfg
+
+    from src.eval.problog_utils import threshold_fn
+
+    # Load results for each LLM
+    all_data = {}   # llm -> {ident: sample} (success only, for ProbLog)
+    labels = {}     # ident -> bool label (all samples, success + fail)
+    for llm in llm_list:
+        result_path = f"eval/{args.version}_{args.dataset}_{llm}/all_results.json"
+        if not os.path.exists(result_path):
+            print(f"  WARNING: {result_path} not found, skipping {llm}")
+            continue
+        with open(result_path) as f:
+            data = json.load(f)
+        successful = {}
+        for s in data:
+            ident = s.get('identifier')
+            if ident and s.get('label') is not None:
+                labels[ident] = s['label']
+            if s.get('success') and ident:
+                successful[ident] = s
+        all_data[llm] = successful
+        print(f"  Loaded {llm}: {len(successful)} success / {len(data)} total")
+
+    if not all_data:
+        print("No results to evaluate!")
+        return
+
+    # n = total dataset size (all samples, not just successful ones)
+    all_ids = sorted(labels.keys())
+    n = len(all_ids)
+    active_llms = sorted(all_data.keys())
+
+    print(f"\n  Evaluating {n} samples, {len(active_llms)} LLMs: {', '.join(active_llms)}")
+    print(f"  Threshold: log(b={thresh_base}, s={thresh_slope})")
+    llm_cfgs = {}
+    for llm in active_llms:
+        llm_cfgs[llm] = _build_llm_config(llm)
+        c = llm_cfgs[llm]
+        ep = "orig" if c["entity_prob"] is None else c["entity_prob"]
+        ag = c["agreement_mode"] or "none"
+        print(f"  {llm}: attr={c['attr_score_type']}, rel={c['rel_score_type']}, "
+              f"ep={ep}, da={c['dampened_alpha']}, ag={ag}")
+
+    # Build work items for parallel ProbLog execution
+    work_items = []
+    for llm in active_llms:
+        cfg = llm_cfgs[llm]
+        for ident, sample in all_data[llm].items():
+            work_items.append((llm, ident, sample, cfg))
+
+    print(f"  {len(work_items)} ProbLog executions across {len(active_llms)} LLMs...")
+
+    # Run ProbLog in parallel
+    slurm_cpus = os.environ.get('SLURM_CPUS_PER_TASK')
+    n_workers = max(1, int(slurm_cpus) - 2) if slurm_cpus else min(mp.cpu_count() - 1, 12)
+
+    t0 = time.time()
+    results_map = {}  # (llm, ident) -> (prove_prob, dep_prob, n_facts)
+
+    if n_workers > 1:
+        with mp.Pool(n_workers, maxtasksperchild=200) as pool:
+            for i, result in enumerate(pool.imap_unordered(_eval_sample_worker, work_items, chunksize=10)):
+                llm, ident, prove_prob, dep_prob, nf = result
+                if prove_prob is not None or dep_prob is not None:
+                    results_map[(llm, ident)] = (prove_prob, dep_prob, nf)
+                if (i + 1) % 500 == 0:
+                    print(f"    {i+1}/{len(work_items)} done ({time.time()-t0:.0f}s)")
+    else:
+        for i, item in enumerate(work_items):
+            result = _eval_sample_worker(item)
+            llm, ident, prove_prob, dep_prob, nf = result
+            if prove_prob is not None or dep_prob is not None:
+                results_map[(llm, ident)] = (prove_prob, dep_prob, nf)
+            if (i + 1) % 200 == 0:
+                print(f"    {i+1}/{len(work_items)} done ({time.time()-t0:.0f}s)")
+
+    print(f"  ProbLog done: {len(results_map)} results in {time.time()-t0:.1f}s")
+
+    # Compute ensemble accuracy
+    prove_correct = 0
+    prove_all_missing = 0
+    deprove_correct = {llm: 0 for llm in active_llms}
+
+    for ident in all_ids:
+        label = labels[ident]
+        llm_prove_probs = []
+        llm_nfacts = []
+
+        for llm in active_llms:
+            entry = results_map.get((llm, ident))
+            if entry is None:
+                # Missing = wrong for DePROVE
+                continue
+            prove_prob, dep_prob, nf = entry
+
+            if prove_prob is not None:
+                llm_prove_probs.append(prove_prob)
+                llm_nfacts.append(nf)
+
+            if dep_prob is not None and (dep_prob >= 0.5) == label:
+                deprove_correct[llm] += 1
+
+        # PROVE: perlm_soft (avg probs over valid LLMs)
+        if llm_prove_probs:
+            avg_prob = sum(llm_prove_probs) / len(llm_prove_probs)
+            avg_nf = sum(llm_nfacts) / len(llm_nfacts)
+            thresh = threshold_fn(avg_nf, thresh_base, thresh_slope)
+            if (avg_prob >= thresh) == label:
+                prove_correct += 1
+        else:
+            prove_all_missing += 1
+
+    # Report
+    print(f"\n{'='*60}")
+    print(f"Results on {args.dataset} (n={n})")
+    print(f"{'='*60}")
+    prove_acc = prove_correct / n * 100
+    print(f"PROVE (perlm_soft): {prove_correct}/{n} = {prove_acc:.2f}%")
+    if prove_all_missing:
+        print(f"  ({prove_all_missing} samples missing all LLMs → wrong)")
+    for llm in active_llms:
+        dep_acc = deprove_correct[llm] / n * 100
+        print(f"DePROVE ({llm}): {deprove_correct[llm]}/{n} = {dep_acc:.2f}%")
+
+    # DePROVE majority vote (if 3+ LLMs)
+    if len(active_llms) >= 3:
+        maj_correct = 0
+        for ident in all_ids:
+            label = labels[ident]
+            votes = []
+            for llm in active_llms:
+                entry = results_map.get((llm, ident))
+                if entry is None:
+                    votes.append(not label)  # missing = wrong
+                else:
+                    _, dep_prob, _ = entry
+                    votes.append(dep_prob >= 0.5 if dep_prob is not None else not label)
+
+            pred = sum(votes) > len(votes) / 2
+            if pred == label:
+                maj_correct += 1
+        print(f"DePROVE (majority): {maj_correct}/{n} = {maj_correct/n*100:.2f}%")
+
+    # Write post-hoc PROVE/DePROVE probs back into each LLM's results file
+    for llm in active_llms:
+        result_path = f"eval/{args.version}_{args.dataset}_{llm}/all_results.json"
+        with open(result_path) as f:
+            data = json.load(f)
+        updated = 0
+        for s in data:
+            ident = s.get('identifier')
+            if not ident:
+                continue
+            entry = results_map.get((llm, ident))
+            if entry is not None:
+                prove_prob, dep_prob, nf = entry
+                thresh = threshold_fn(nf, thresh_base, thresh_slope)
+                s['posthoc_prove_prob'] = prove_prob
+                s['posthoc_prove_pred'] = prove_prob >= thresh if prove_prob is not None else None
+                s['posthoc_deprove_prob'] = dep_prob
+                s['posthoc_deprove_pred'] = dep_prob >= 0.5 if dep_prob is not None else None
+                s['posthoc_n_facts'] = nf
+                updated += 1
+        with open(result_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        print(f"  Wrote posthoc probs to {result_path} ({updated} samples)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PROVE evaluation with dual scoring")
+    parser.add_argument("--llm", nargs='+', choices=list(LLM_MODELS.keys()),
+                        help=f"LLM(s) for ProbLog generation. Single LLM runs pipeline; "
+                             f"multiple LLMs run in parallel then evaluate ensemble. "
+                             f"Choices: {', '.join(LLM_MODELS.keys())}")
+    parser.add_argument("--dataset", default="test1",
+                        help=f"Dataset preset ({', '.join(DATASET_PRESETS.keys())}) "
+                             f"or 'nlvr2'/'gqa' for manual paths")
+    parser.add_argument("--version", default="v5",
+                        help="Version prefix for auto output_dir (default: v5)")
+    parser.add_argument("--data_root", default=None,
+                        help="Root directory for datasets (overrides PROVE_DATA_ROOT env var)")
+    parser.add_argument("--test_json", default=None,
+                        help="Path to test data (overrides dataset preset)")
+    parser.add_argument("--img_dir", default=None,
+                        help="Path to images directory (overrides dataset preset)")
+    parser.add_argument("--output_dir", default=None,
+                        help="Output directory (auto-generated from --version/--dataset/--llm if not set)")
+    parser.add_argument("--max_samples", type=int, default=0,
+                        help="Max samples to process (0 = all)")
+    parser.add_argument("--resume_from", type=int, default=0,
+                        help="Resume from this sample index")
+    parser.add_argument("--end_at", type=int, default=0,
+                        help="Stop at this sample index (0 = process all)")
+    parser.add_argument("--z_filter", type=int, default=None, choices=[0, 1],
+                        help="Only keep samples with this Z value (0 or 1) to avoid duplicates (NLVR2 only)")
+    parser.add_argument("--thinking_budget", type=int, default=None,
+                        help="Enable Claude extended thinking with this token budget (e.g. 4096)")
+    parser.add_argument("--cot", action="store_true",
+                        help="Enable prompt-level chain-of-thought reasoning")
+    parser.add_argument("--blip_lora_path", type=str, default=None,
+                        help="Path to fine-tuned BLIP LoRA adapter (e.g. eval/vqa_finetune/blip_lora_best)")
+    parser.add_argument("--retry_failed", action="store_true",
+                        help="Remove failed entries from results and retry them")
+
+    # ── Scoring config ───────────────────────────────────────────────
+    parser.add_argument("--config", type=str, default="v5_perlm",
+                        choices=list(_ALL_CONFIGS.keys()),
+                        help="Scoring config preset from configs.json (default: v5_perlm)")
+    # Per-LLM overrides (optional, override the preset):
+    parser.add_argument("--attr_score", nargs='+', default=None,
+                        help="Attribute score type override. Values: blip_score, qwen_tf_score, avg_blip_qwen_tf")
+    parser.add_argument("--rel_score", nargs='+', default=None,
+                        help="Relation score type override. Same values as --attr_score")
+    parser.add_argument("--entity_prob", nargs='+', default=None,
+                        help="Entity probability override: 'orig' or a float")
+    parser.add_argument("--dampened_alpha", nargs='+', default=None,
+                        help="Dampening alpha override: float, 1.0=standard, <1=dampened")
+    parser.add_argument("--agreement", nargs='+', default=None,
+                        help="VQA agreement override: none, sharpen, dampen_0.5, dampen_0.3, both")
+    parser.add_argument("--thresh_base", type=float, default=None,
+                        help="Log threshold base (default: from config preset)")
+    parser.add_argument("--thresh_slope", type=float, default=None,
+                        help="Log threshold slope (default: from config preset)")
+    args = parser.parse_args()
+
+    # ── Multi-LLM mode: orchestrate parallel runs + ensemble eval ─────
+    if args.llm and len(args.llm) > 1:
+        run_multi_llm(args)
+        return
+
+    # ── Single-LLM mode: extract from list ────────────────────────────
+    if args.llm:
+        args.llm = args.llm[0]
+        os.environ["LLAMA33_MODEL_ID"] = LLM_MODELS[args.llm]
+        print(f"LLM: {args.llm} → {LLM_MODELS[args.llm]}")
+
+    # ── Resolve data_root: CLI > env var > error ─────────────────────────
+    data_root = args.data_root or os.environ.get("PROVE_DATA_ROOT", "")
+
+    # ── Resolve dataset preset ───────────────────────────────────────────
+    if args.dataset in DATASET_PRESETS:
+        preset = DATASET_PRESETS[args.dataset]
+        if args.test_json is None:
+            args.test_json = os.path.join(data_root, preset["test_json"])
+        if args.img_dir is None:
+            args.img_dir = os.path.join(data_root, preset["img_dir"])
+        if args.z_filter is None and preset["z_filter"] is not None:
+            args.z_filter = preset["z_filter"]
+        # Map preset type for pipeline logic
+        is_gqa_dataset = preset["type"] == "gqa"
+    elif args.dataset == "gqa":
+        if args.test_json is None:
+            args.test_json = os.path.join(data_root, "gqa_data/testdev_balanced_yn.json")
+        if args.img_dir is None:
+            args.img_dir = os.path.join(data_root, "gqa_data/images")
+        is_gqa_dataset = True
+    else:
+        # Fallback: treat as nlvr2
+        if args.test_json is None:
+            args.test_json = os.path.join(data_root, "nlvr2_data/balanced_test1.json")
+        if args.img_dir is None:
+            args.img_dir = os.path.join(data_root, "nlvr2_data/images")
+        is_gqa_dataset = False
+
+    # ── Auto-generate output_dir ─────────────────────────────────────────
+    if args.output_dir is None:
+        llm_suffix = f"_{args.llm}" if args.llm else ""
+        dataset_name = args.dataset if args.dataset in DATASET_PRESETS else args.dataset
+        args.output_dir = f"eval/{args.version}_{dataset_name}{llm_suffix}"
+        print(f"Output dir: {args.output_dir}")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Load test data
+    is_gqa = is_gqa_dataset
+    print(f"Loading test data ({args.dataset})...")
+
+    if is_gqa:
+        samples = load_gqa_samples(args.test_json, args.img_dir)
+    else:
+        # NLVR2: JSONL format
+        samples = []
+        with open(args.test_json) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    samples.append(json.loads(line))
+
+        # Filter by Z value to avoid duplicate image pairs
+        if args.z_filter is not None:
+            before = len(samples)
+            samples = [s for s in samples if s['identifier'].endswith(f'-{args.z_filter}')]
+            print(f"Filtered Z={args.z_filter}: {before} → {len(samples)} samples")
+
+    # Pre-filter to samples with valid images, then apply max_samples
+    if args.max_samples > 0:
+        valid_samples = []
+        skipped = 0
+        for s in samples:
+            if is_gqa:
+                valid = os.path.exists(s["image_path"])
+            else:
+                img_a, img_b = nlvr2_id_to_image_paths(
+                    s["identifier"], args.img_dir, directory=s.get("directory"))
+                valid = os.path.exists(img_a) and os.path.exists(img_b)
+            if valid:
+                valid_samples.append(s)
+                if len(valid_samples) >= args.max_samples:
+                    break
+            else:
+                skipped += 1
+        print(f"Skipped {skipped} samples with missing images")
+        samples = valid_samples
+    print(f"Loaded {len(samples)} samples")
+
+    # Initialize models
+    print("Initializing models...")
+    mm = ModelManager()
+
+    # Pre-initialize LLM client with model ID and thinking/CoT settings
+    # (singleton ensures all pipeline components use the same instance)
+    from src.language.llm_client import LLMClient
+    model_id = os.getenv("LLAMA33_MODEL_ID")
+    if args.thinking_budget or args.cot or model_id:
+        if args.thinking_budget:
+            print(f"Enabling extended thinking with budget={args.thinking_budget} tokens")
+        if args.cot:
+            print(f"Enabling prompt-level chain-of-thought")
+        print(f"Model ID: {model_id}")
+        mm._models['llm_client'] = LLMClient(
+            model_id=model_id,
+            thinking_budget=args.thinking_budget,
+            cot_enabled=args.cot
+        )
+
+    # Load fine-tuned BLIP if LoRA path provided
+    if args.blip_lora_path:
+        print(f"Using fine-tuned BLIP from {args.blip_lora_path}")
+        mm._models['blip_verifier'] = BLIPVerifier(device="auto", lora_path=args.blip_lora_path)
+
+    detector = Detector()
+    executor = ProbLogExecutor()
+    fact_builder = ProbLogFactBuilder()
+
+    # Initialize Qwen verifier and pass to agent as extra verifier
+    qwen_vl = mm.get_qwen_vl()
+    qwen_tf = QwenVerifier(qwen_vl=qwen_vl)
+    agent = UnifiedAgent(max_iterations=20, extra_verifiers={"qwen_tf": qwen_tf})
+
+    print("All models loaded.\n")
+
+    # Process samples
+    results_file = os.path.join(args.output_dir, "all_results.json")
+
+    # Always load existing results to support preemption recovery
+    all_results = []
+    done_identifiers = set()
+    if os.path.exists(results_file):
+        try:
+            with open(results_file) as f:
+                all_results = json.load(f)
+            if args.retry_failed:
+                # Only skip successful samples — retry failed ones
+                failed_ids = {r.get('identifier') for r in all_results if not r.get('success') and r.get('identifier')}
+                all_results = [r for r in all_results if r.get('success')]
+                done_identifiers = {r.get('identifier') for r in all_results if r.get('identifier')}
+                print(f"Loaded {len(all_results)} successful results, removed {len(failed_ids)} failed for retry")
+            else:
+                done_identifiers = {r.get('identifier') for r in all_results if r.get('identifier')}
+                print(f"Loaded {len(all_results)} existing results from {results_file} "
+                      f"({len(done_identifiers)} unique identifiers)")
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Warning: could not load existing results: {e}")
+            all_results = []
+
+    n_success = sum(1 for r in all_results if r.get("success"))
+    n_fail = sum(1 for r in all_results if not r.get("success"))
+    start_time = time.time()
+
+    for idx, sample in enumerate(tqdm(samples, desc="Evaluating")):
+        if idx < args.resume_from:
+            continue
+        if args.end_at > 0 and idx >= args.end_at:
+            break
+
+        identifier = sample["identifier"]
+
+        # Skip already-processed samples (preemption recovery)
+        if identifier in done_identifiers:
+            continue
+        sentence = sample["sentence"]
+        label_str = sample.get("label", "False")
+        label = label_str if isinstance(label_str, bool) else label_str.lower() == "true"
+
+        # Build image_paths dict based on dataset type
+        if is_gqa:
+            img_path = sample["image_path"]
+            image_paths = {"image_a": img_path}
+            missing_images = not os.path.exists(img_path)
+        else:
+            img_a_path, img_b_path = nlvr2_id_to_image_paths(
+                identifier, args.img_dir, directory=sample.get("directory"))
+            image_paths = {"image_a": img_a_path, "image_b": img_b_path}
+            missing_images = not os.path.exists(img_a_path) or not os.path.exists(img_b_path)
+
+        result = {
+            "identifier": identifier,
+            "sentence": sentence,
+            "label": label,
+            "success": False,
+        }
+
+        if missing_images:
+            result["error"] = "Image files not found"
+            all_results.append(result)
+            n_fail += 1
+            continue
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+
+                # Step 1: Detection
+                kb = KnowledgeBase(ultimate_question=sentence)
+                for image_id, image_path in image_paths.items():
+                    detections = detector.detect_from_question(image_path, sentence)
+                    kb.add_objects(image_id, detections)
+
+                # Save detection info
+                det_info = {}
+                for image_id, image_data in kb.images.items():
+                    det_info[image_id] = [
+                        {"label": obj.label, "bbox": obj.bbox,
+                         "confidence": obj.confidence, "object_id": obj.object_id}
+                        for obj in image_data.objects
+                    ]
+                result["detections"] = det_info
+
+                # Step 2: Evidence collection (uses BLIP for verification)
+                evidence = agent.collect_evidence(
+                    question=sentence,
+                    images=kb.images,
+                    image_paths=image_paths
+                )
+
+                # Step 3: Build evidence output (scores collected during evidence collection)
+                count_data = []
+                for ce in evidence.counts:
+                    count_data.append({
+                        "query_type": ce.query_type,
+                        "object_class": ce.object_class,
+                        "probability": ce.probability,
+                        "image_id": ce.image_id,
+                        "image_id_a": ce.image_id_a,
+                        "image_id_b": ce.image_id_b,
+                        "value": ce.value,
+                    })
+
+                result["evidence"] = {
+                    "attributes": evidence.attribute_scores,
+                    "relationships": evidence.relationship_scores,
+                    "counts": count_data,
+                    "action_history": evidence.action_history,
+                }
+
+                # Step 4: ProbLog execution
+                prob_facts = fact_builder.build_facts(evidence, kb.images)
+
+                # Save facts for post-hoc re-execution
+                facts_data = [
+                    {"predicate": f.predicate, "arguments": f.arguments,
+                     "probability": f.probability}
+                    for f in prob_facts
+                ]
+
+                # Run ProbLog with BLIP scores (default)
+                prob_result, det_result = executor.execute_dual(
+                    question=sentence,
+                    evidence=evidence,
+                    images=kb.images,
+                    threshold=0.5
+                )
+
+                result["problog"] = {
+                    "rules": "",  # Will be filled from problog_program
+                    "query": "",
+                    "facts": facts_data,
+                }
+
+                # Extract rules and query from problog program
+                program = prob_result.problog_program
+                if program:
+                    # Parse rules and query from the program string
+                    lines = program.split("\n")
+                    rule_lines = []
+                    query_lines = []
+                    for line in lines:
+                        stripped = line.strip()
+                        if stripped.startswith("query("):
+                            query_lines.append(stripped)
+                        elif stripped and not stripped.startswith("%") and "::" not in stripped:
+                            rule_lines.append(stripped)
+                    result["problog"]["rules"] = "\n".join(rule_lines)
+                    result["problog"]["query"] = "\n".join(query_lines)
+
+                result["results"] = {
+                    "prove_answer": prob_result.final_answer,
+                    "deprove_answer": det_result.final_answer,
+                    "prove_prob": prob_result.probability,
+                    "deprove_prob": det_result.probability,
+                    "prove_program": prob_result.problog_program,
+                    "deprove_program": det_result.problog_program,
+                }
+
+                result["success"] = True
+                n_success += 1
+                break
+
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    print(f"  RETRY {attempt+1}/{max_retries}: {identifier}: {e}")
+                    time.sleep(2)
+                else:
+                    result["error"] = str(e)
+                    result["traceback"] = traceback.format_exc()
+                    result["retries"] = max_retries
+                    n_fail += 1
+                    print(f"  FAILED after {max_retries} attempts: {identifier}: {e}")
+
+        all_results.append(result)
+
+        # Periodic save and cleanup
+        if (idx + 1) % 25 == 0:
+            with open(results_file, "w") as f:
+                json.dump(all_results, f, indent=2)
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+            elapsed = time.time() - start_time
+            rate = (idx + 1 - args.resume_from) / elapsed * 3600
+            print(f"\n  Progress: {idx+1}/{len(samples)}, "
+                  f"success={n_success}, fail={n_fail}, "
+                  f"rate={rate:.0f}/hr, "
+                  f"elapsed={elapsed/60:.1f}min")
+
+    # Final save
+    with open(results_file, "w") as f:
+        json.dump(all_results, f, indent=2)
+
+    # Print summary
+    elapsed = time.time() - start_time
+    print(f"\n{'='*60}")
+    print(f"EVALUATION COMPLETE")
+    print(f"{'='*60}")
+    print(f"Total: {len(all_results)}, Success: {n_success}, Failed: {n_fail}")
+    print(f"Time: {elapsed/60:.1f} minutes ({elapsed/3600:.1f} hours)")
+
+    # Quick accuracy check
+    successful = [r for r in all_results if r.get("success")]
+    if successful:
+        prove_correct = sum(1 for r in successful
+                           if (r["results"]["prove_answer"] == "True") == r["label"])
+        deprove_correct = sum(1 for r in successful
+                             if (r["results"]["deprove_answer"] == "True") == r["label"])
+        total = len(successful)
+        print(f"\nPROVE accuracy:   {prove_correct}/{total} = {prove_correct/total*100:.1f}%")
+        print(f"DePROVE accuracy: {deprove_correct}/{total} = {deprove_correct/total*100:.1f}%")
+
+        # McNemar's test
+        pw = sum(1 for r in successful
+                 if (r["results"]["prove_answer"] == "True") == r["label"]
+                 and (r["results"]["deprove_answer"] == "True") != r["label"])
+        dw = sum(1 for r in successful
+                 if (r["results"]["deprove_answer"] == "True") == r["label"]
+                 and (r["results"]["prove_answer"] == "True") != r["label"])
+        chi2 = (abs(pw - dw) - 1)**2 / (pw + dw) if (pw + dw) > 0 else 0
+        sig = "***" if chi2 > 3.84 and pw > dw else ""
+        print(f"McNemar: PW={pw}, DW={dw}, chi²={chi2:.2f} {sig}")
+
+    print(f"\nResults saved to {results_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/run_example.py
+++ b/src/eval/run_example.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Run PROVE pipeline on a single example from NLVR2 or GQA.
+
+Usage:
+    python run_example.py                                          # random NLVR2 example
+    python run_example.py --identifier test1-366-0-0               # specific NLVR2 example
+    python run_example.py --dataset gqa                            # random GQA example
+    python run_example.py --dataset gqa --identifier 201307251     # specific GQA example
+    python run_example.py --save-logs                              # save detailed logs
+"""
+
+import argparse
+import json
+import os
+import random
+
+from src import PROVE
+
+
+# Default data paths (set PROVE_DATA_ROOT env var or use --data-file/--img-dir)
+_DATA_ROOT = os.environ.get("PROVE_DATA_ROOT", "")
+NLVR2_DATA = f"{_DATA_ROOT}/nlvr2_data/balanced_test1.json"
+NLVR2_IMAGES = f"{_DATA_ROOT}/nlvr2_data/images"
+GQA_DATA = f"{_DATA_ROOT}/gqa_data/testdev_balanced_yn.json"
+GQA_IMAGES = f"{_DATA_ROOT}/gqa_data/images"
+
+
+def load_nlvr2_examples(data_file, img_dir):
+    """Load NLVR2 examples where both images exist."""
+    examples = []
+    with open(data_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            ex = json.loads(line)
+            ident = ex["identifier"]
+            prefix = ident.rsplit("-", 1)[0]
+            img0 = os.path.join(img_dir, f"{prefix}-img0.png")
+            img1 = os.path.join(img_dir, f"{prefix}-img1.png")
+            if os.path.exists(img0) and os.path.exists(img1):
+                examples.append({
+                    "identifier": ident,
+                    "question": ex["sentence"],
+                    "label": ex["label"] == "True" if isinstance(ex["label"], str) else bool(ex["label"]),
+                    "image_paths": {"image_a": img0, "image_b": img1},
+                })
+    return examples
+
+
+def load_gqa_examples(data_file, img_dir):
+    """Load GQA yes/no examples where image exists."""
+    with open(data_file) as f:
+        data = json.load(f)
+    examples = []
+    for qid, entry in data.items():
+        img_id = entry["imageId"]
+        img_path = os.path.join(img_dir, f"{img_id}.jpg")
+        if not os.path.exists(img_path):
+            continue
+        answer = entry["answer"].strip().lower()
+        if answer not in ("yes", "no"):
+            continue
+        examples.append({
+            "identifier": qid,
+            "question": entry["question"],
+            "label": answer == "yes",
+            "image_paths": {"image_a": img_path},
+        })
+    return examples
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run PROVE on a single example")
+    parser.add_argument("--dataset", choices=["nlvr2", "gqa"], default="nlvr2",
+                        help="Dataset to use (default: nlvr2)")
+    parser.add_argument("--identifier", type=str, help="Specific example identifier")
+    parser.add_argument("--save-logs", action="store_true", help="Save detailed logs")
+    parser.add_argument("--threshold", type=float, default=0.5,
+                        help="Decision threshold (default: 0.5)")
+    parser.add_argument("--data-file", type=str, help="Override default data file path")
+    parser.add_argument("--img-dir", type=str, help="Override default image directory")
+    args = parser.parse_args()
+
+    # Set paths
+    if args.dataset == "gqa":
+        data_file = args.data_file or GQA_DATA
+        img_dir = args.img_dir or GQA_IMAGES
+    else:
+        data_file = args.data_file or NLVR2_DATA
+        img_dir = args.img_dir or NLVR2_IMAGES
+
+    # Load examples
+    print(f"Loading {args.dataset.upper()} examples from {data_file}...")
+    if args.dataset == "gqa":
+        examples = load_gqa_examples(data_file, img_dir)
+    else:
+        examples = load_nlvr2_examples(data_file, img_dir)
+    print(f"Found {len(examples)} valid examples\n")
+
+    if not examples:
+        print("No valid examples found. Check data and image paths.")
+        return
+
+    # Select example
+    if args.identifier:
+        example = next((e for e in examples if e["identifier"] == args.identifier), None)
+        if not example:
+            print(f"Example '{args.identifier}' not found")
+            return
+    else:
+        example = random.choice(examples)
+
+    # Print info
+    print("=" * 60)
+    print(f"Dataset:      {args.dataset.upper()}")
+    print(f"Example:      {example['identifier']}")
+    print(f"Question:     {example['question']}")
+    print(f"Ground Truth: {example['label']}")
+    print(f"Images:       {list(example['image_paths'].keys())}")
+    print("=" * 60)
+
+    # Run PROVE
+    model = PROVE(threshold=args.threshold)
+
+    try:
+        result = model.predict_with_details(
+            image_paths=example["image_paths"],
+            question=example["question"],
+            save_logs=args.save_logs,
+            log_dir="logs"
+        )
+
+        prob_correct = (result.probabilistic.final_answer == example["label"])
+        det_correct = (result.deterministic.final_answer == example["label"])
+
+        print("\n" + "=" * 60)
+        print("EVALUATION")
+        print("=" * 60)
+        print(f"Ground Truth:    {example['label']}")
+        print(f"Probabilistic:   {result.probabilistic.final_answer} "
+              f"({'CORRECT' if prob_correct else 'WRONG'})")
+        print(f"Deterministic:   {result.deterministic.final_answer} "
+              f"({'CORRECT' if det_correct else 'WRONG'})")
+        print("=" * 60)
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/run_prove_sweep.py
+++ b/src/eval/run_prove_sweep.py
@@ -1,0 +1,1004 @@
+#!/usr/bin/env python3
+"""
+Clean PROVE-only sweep — finalized strategies for the paper.
+
+Dimensions:
+1. VQA scoring (attr × rel, with mix-and-match)
+2. Entity probability (original, 1.0, 0.99, 0.9)
+3. Dampening alpha (1.0, 0.9, 0.8, 0.7)
+4. VQA agreement adjustment (none, agree_0.5, agree_0.3)
+5. PROVE threshold (fixed + dynamic logarithmic)
+6. LLM combos (singles + all ensemble sizes 2..N; soft + hard vote)
+
+All post-hoc — zero API calls.
+"""
+
+import gc
+import heapq
+import os
+import sys
+import json
+import time
+import math
+import pickle
+import multiprocessing as mp
+import numpy as np
+from itertools import combinations
+from collections import defaultdict
+
+from pathlib import Path
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, _PROJECT_ROOT)
+
+from problog.evaluator import SemiringProbability
+
+from src.eval.problog_utils import (
+    SemiringDampened, quote_arg, build_score_lookups, get_score,
+    rebuild_facts, execute_problog_direct,
+)
+
+
+# ─── Data paths ──────────────────────────────────────────────────────────────
+
+_DEFAULT_RESULT_FILES = {
+    'maverick': 'eval/v3_baseline_maverick/all_results_entity_fixed.json',
+    'llama': 'eval/v3_baseline_llama/all_results_entity_fixed.json',
+    'nova_pro': 'eval/nova_pro_fixed/all_results_entity_fixed.json',
+    'nova_premier': 'eval/nova_premier_fixed/all_results.json',
+}
+
+# Allow env var override: PROVE_SWEEP_RESULT_FILES='{"maverick":"path",...}'
+if os.environ.get('PROVE_SWEEP_RESULT_FILES'):
+    LLM_RESULT_FILES = json.loads(os.environ['PROVE_SWEEP_RESULT_FILES'])
+    print(f"Using result files from PROVE_SWEEP_RESULT_FILES env var")
+else:
+    LLM_RESULT_FILES = _DEFAULT_RESULT_FILES
+
+OUTPUT_DIR = os.environ.get('PROVE_SWEEP_OUTPUT_DIR', 'eval/prove_sweep')
+
+
+# ─── Parallel worker (batch) ────────────────────────────────────────────────
+
+def _worker_batch(batch, result_queue, worker_id):
+    """Process a batch of work items in a subprocess. Writes results to queue.
+    This runs as a standalone mp.Process so the parent can kill() it on timeout.
+    Tags each result with worker_id so the parent can identify timed-out items."""
+    for work_item in batch:
+        score_key, ident, facts, rules, query, da = work_item
+        sr = SemiringDampened(alpha=da) if da != 1.0 else None
+        prove_prob = execute_problog_direct(facts, rules, query, semiring=sr)
+
+        dep_facts = [{**f, 'probability': 1.0 if f['probability'] >= 0.5 else 0.0}
+                     for f in facts]
+        dep_prob = execute_problog_direct(dep_facts, rules, query, semiring=None)
+
+        if prove_prob is None and dep_prob is None:
+            result_queue.put((worker_id, ident, None))
+        else:
+            result_queue.put((worker_id, ident, (score_key, ident, (prove_prob, dep_prob, len(facts)))))
+
+
+def _run_parallel_with_timeout(gen, n_workers, progress_cb, timed_out_idents,
+                                batch_size=50, timeout_per_item=30):
+    """Run work items in parallel using mp.Process workers with hard kill timeouts.
+
+    Unlike mp.Pool, each worker is a plain Process that can be kill()'d if it hangs.
+    Workers process batches of items; if a worker exceeds its time budget, it's killed.
+    When a batch is killed, the first non-completed item's identifier is added to
+    timed_out_idents so the generator can skip that sample for all future configs.
+    """
+    result_queue = mp.Queue()
+    active = {}  # pid -> (process, deadline, batch_idents)
+    results = []
+    next_worker_id = [0]
+    completed_by_worker = defaultdict(set)  # worker_id -> set of completed idents
+
+    def _collect_results():
+        """Drain the result queue without blocking."""
+        collected = 0
+        while not result_queue.empty():
+            try:
+                wid, ident, r = result_queue.get_nowait()
+                completed_by_worker[wid].add(ident)
+                if r is not None:
+                    results.append(r)
+                collected += 1
+            except:
+                break
+        return collected
+
+    def _reap_done():
+        """Join finished workers."""
+        for pid in list(active):
+            proc, deadline, wid, batch_idents = active[pid]
+            if not proc.is_alive():
+                proc.join(timeout=1)
+                completed_by_worker.pop(wid, None)
+                del active[pid]
+
+    def _kill_expired():
+        """Kill workers that exceeded their time budget. Identify hanging samples."""
+        now = time.time()
+        for pid in list(active):
+            proc, deadline, wid, batch_idents = active[pid]
+            if now > deadline:
+                proc.kill()
+                proc.join(timeout=5)
+                # Drain any results this worker put on the queue before dying
+                _collect_results()
+                # Find the first item that didn't complete — that's the one that hung
+                completed = completed_by_worker.get(wid, set())
+                for ident in batch_idents:
+                    if ident not in completed:
+                        timed_out_idents.add(ident)
+                        print(f"    TIMEOUT: {ident} added to skip list ({len(timed_out_idents)} total)")
+                        break
+                completed_by_worker.pop(wid, None)
+                del active[pid]
+
+    # Buffer work items into batches
+    batch = []
+    items_submitted = 0
+
+    for item in gen:
+        batch.append(item)
+        if len(batch) >= batch_size:
+            # Wait for a slot
+            while len(active) >= n_workers:
+                _collect_results()
+                _reap_done()
+                _kill_expired()
+                if len(active) >= n_workers:
+                    time.sleep(0.05)
+
+            wid = next_worker_id[0]
+            next_worker_id[0] += 1
+            batch_idents = [item[1] for item in batch]  # item[1] is ident
+            # Deadline: generous time for fast items + one timeout for a hanging item
+            # Most items finish in <0.5s; if one hangs, we detect it after timeout_per_item
+            deadline = time.time() + len(batch) * 1.0 + timeout_per_item
+            p = mp.Process(target=_worker_batch, args=(batch, result_queue, wid))
+            p.start()
+            active[p.pid] = (p, deadline, wid, batch_idents)
+            items_submitted += len(batch)
+            batch = []
+
+            # Progress reporting
+            _collect_results()
+            progress_cb(len(results))
+
+    # Submit final partial batch
+    if batch:
+        while len(active) >= n_workers:
+            _collect_results()
+            _reap_done()
+            _kill_expired()
+            if len(active) >= n_workers:
+                time.sleep(0.05)
+        wid = next_worker_id[0]
+        next_worker_id[0] += 1
+        batch_idents = [item[1] for item in batch]
+        deadline = time.time() + len(batch) * 1.0 + timeout_per_item
+        p = mp.Process(target=_worker_batch, args=(batch, result_queue, wid))
+        p.start()
+        active[p.pid] = (p, deadline, wid, batch_idents)
+        items_submitted += len(batch)
+
+    # Wait for all workers to finish
+    while active:
+        _collect_results()
+        _reap_done()
+        _kill_expired()
+        if active:
+            time.sleep(0.1)
+        progress_cb(len(results))
+
+    # Final drain
+    _collect_results()
+    return results
+
+
+# ─── Data loading ────────────────────────────────────────────────────────────
+
+def build_llm_index(samples):
+    idx = {}
+    for s in samples:
+        ident = s.get('identifier')
+        if ident and s.get('success', False) and s.get('label') is not None:
+            idx[ident] = s
+    return idx
+
+
+def mcnemar_chi2(correct_a, correct_b):
+    pw = sum(1 for a, b in zip(correct_a, correct_b) if a and not b)
+    dw = sum(1 for a, b in zip(correct_a, correct_b) if b and not a)
+    chi2 = ((pw - dw) ** 2) / (pw + dw) if (pw + dw) > 0 else 0.0
+    return chi2, pw, dw
+
+
+# ─── Threshold strategies ────────────────────────────────────────────────────
+
+def make_threshold_configs():
+    """
+    Return list of (name, params) tuples where params is a dict describing
+    the threshold type and parameters for vectorized evaluation.
+    """
+    configs = []
+
+    # Fixed thresholds: fine steps from 0.05 to 0.55
+    for t_int in range(5, 56, 1):
+        t = t_int / 100.0
+        configs.append((f"t={t:.2f}", {'type': 'fixed', 'value': t}))
+
+    # Dynamic logarithmic: threshold = base + slope * log(n_facts + 1)
+    for base in [0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50]:
+        for slope in [-0.12, -0.10, -0.08, -0.06, -0.04, -0.02, 0.0, 0.02, 0.04, 0.06, 0.08, 0.10]:
+            name = f"log(b={base},s={slope})"
+            configs.append((name, {'type': 'log', 'base': base, 'slope': slope}))
+
+    # Dynamic linear: threshold = base + slope * n_facts
+    for base in [0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50]:
+        for slope in [-0.025, -0.020, -0.015, -0.010, -0.005, 0.0, 0.005, 0.010, 0.015, 0.020]:
+            name = f"lin(b={base},s={slope})"
+            configs.append((name, {'type': 'linear', 'base': base, 'slope': slope}))
+
+    # Binned: different thresholds for few/medium/many facts
+    binned = [
+        ("bin5_15(0.3/0.5/0.7)",  {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.3, 't2': 0.5, 't3': 0.7}),
+        ("bin5_15(0.4/0.5/0.6)",  {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.4, 't2': 0.5, 't3': 0.6}),
+        ("bin5_15(0.5/0.4/0.3)",  {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.5, 't2': 0.4, 't3': 0.3}),
+        ("bin5_15(0.6/0.5/0.4)",  {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.6, 't2': 0.5, 't3': 0.4}),
+        ("bin5_15(0.3/0.35/0.4)", {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.3, 't2': 0.35, 't3': 0.4}),
+        ("bin5_15(0.4/0.35/0.3)", {'type': 'binned', 'b1': 5, 'b2': 15, 't1': 0.4, 't2': 0.35, 't3': 0.3}),
+        ("bin8_20(0.3/0.5/0.7)",  {'type': 'binned', 'b1': 8, 'b2': 20, 't1': 0.3, 't2': 0.5, 't3': 0.7}),
+        ("bin8_20(0.4/0.5/0.6)",  {'type': 'binned', 'b1': 8, 'b2': 20, 't1': 0.4, 't2': 0.5, 't3': 0.6}),
+        ("bin8_20(0.5/0.4/0.3)",  {'type': 'binned', 'b1': 8, 'b2': 20, 't1': 0.5, 't2': 0.4, 't3': 0.3}),
+        ("bin8_20(0.4/0.35/0.3)", {'type': 'binned', 'b1': 8, 'b2': 20, 't1': 0.4, 't2': 0.35, 't3': 0.3}),
+        ("bin10_25(0.3/0.4/0.5)", {'type': 'binned', 'b1': 10, 'b2': 25, 't1': 0.3, 't2': 0.4, 't3': 0.5}),
+        ("bin10_25(0.5/0.4/0.3)", {'type': 'binned', 'b1': 10, 'b2': 25, 't1': 0.5, 't2': 0.4, 't3': 0.3}),
+    ]
+    configs.extend(binned)
+
+    return configs
+
+
+def compute_thresholds_vectorized(nfacts_arr, threshold_configs):
+    """
+    Compute threshold values for all configs at once.
+    nfacts_arr: shape [...] (any shape)
+    Returns: [n_thresholds, ...] array of threshold values.
+    """
+    n_thr = len(threshold_configs)
+    result = np.empty((n_thr,) + nfacts_arr.shape)
+
+    for ti, (name, params) in enumerate(threshold_configs):
+        ttype = params['type']
+        if ttype == 'fixed':
+            result[ti] = params['value']
+        elif ttype == 'log':
+            result[ti] = np.clip(params['base'] + params['slope'] * np.log(nfacts_arr + 1), 0.0, 1.0)
+        elif ttype == 'linear':
+            result[ti] = np.clip(params['base'] + params['slope'] * nfacts_arr, 0.0, 1.0)
+        elif ttype == 'binned':
+            b1, b2 = params['b1'], params['b2']
+            t1, t2, t3 = params['t1'], params['t2'], params['t3']
+            result[ti] = np.where(nfacts_arr <= b1, t1, np.where(nfacts_arr <= b2, t2, t3))
+
+    return result
+
+
+# ─── Score configs ───────────────────────────────────────────────────────────
+
+def make_score_configs():
+    """
+    Build all (attr_score, rel_score, entity_prob, dampening, agreement) combos.
+    Returns dict: key -> config dict.
+    """
+    ALL_SCORES = [
+        'blip_score', 'qwen_tf_score',
+        'avg_blip_qwen_tf',
+    ]
+
+    # Same score for both attrs and rels
+    scoring_pairs = [(s, s) for s in ALL_SCORES]
+
+    # Mix-and-match: permutations of {blip, qwen_tf, avg_blip_qwen_tf} where attr != rel
+    mix_types = ['blip_score', 'qwen_tf_score', 'avg_blip_qwen_tf']
+    for a in mix_types:
+        for r in mix_types:
+            if a != r:
+                scoring_pairs.append((a, r))
+
+    entity_probs = [None, 1.0, 0.99, 0.9]
+    dampening_alphas = [1.0, 0.9, 0.8, 0.7]
+    agreement_modes = [None, 'dampen_0.5', 'dampen_0.3', 'sharpen', 'both']
+
+    configs = {}
+    for attr_st, rel_st in scoring_pairs:
+        if attr_st == rel_st:
+            score_label = attr_st
+        else:
+            # Shorten names for readability
+            short = lambda s: s.replace('_score', '').replace('avg_blip_qwen_', 'abq_')
+            score_label = f"A:{short(attr_st)}/R:{short(rel_st)}"
+
+        for ep in entity_probs:
+            ep_label = 'orig' if ep is None else str(ep)
+            for da in dampening_alphas:
+                for am in agreement_modes:
+                    am_label = am if am else 'none'
+                    key = f"{score_label}|ep={ep_label}|da={da}|ag={am_label}"
+                    configs[key] = {
+                        'attr_score_type': attr_st,
+                        'rel_score_type': rel_st,
+                        'entity_prob': ep,
+                        'dampened_alpha': da,
+                        'agreement_mode': am,
+                    }
+
+    return configs
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRECOMPUTATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _work_item_generator(llm_name, idx, all_ids, score_configs, timed_out_idents):
+    """Yield work items lazily. Checks timed_out_idents (shared set updated by
+    the parallel runner) to skip samples that have already timed out."""
+    skipped = 0
+    for score_key, score_cfg in score_configs.items():
+        ast = score_cfg['attr_score_type']
+        rst = score_cfg['rel_score_type']
+        ep = score_cfg.get('entity_prob')
+        da = score_cfg.get('dampened_alpha', 1.0)
+        am = score_cfg.get('agreement_mode')
+
+        for ident in all_ids:
+            if ident in timed_out_idents:
+                skipped += 1
+                continue
+            sample = idx.get(ident)
+            if sample is None:
+                continue
+
+            facts = rebuild_facts(sample, ast, rst, entity_prob=ep, agreement_mode=am)
+            if facts is None:
+                continue
+
+            rules = sample.get('problog', {}).get('rules')
+            query = sample.get('problog', {}).get('query')
+            if not rules or not query:
+                continue
+
+            yield (score_key, ident, facts, rules, query, da)
+
+
+def precompute_all(all_llm_indices, all_ids_by_llm, score_configs):
+    """
+    Precompute ProbLog results for all (LLM, score_config, sample) combinations.
+    Returns: precomputed[llm][(score_key, ident)] = (prove_prob, deprove_prob, num_facts)
+
+    Caches per-LLM results to disk so completed LLMs can be skipped on restart.
+    """
+    slurm_cpus = os.environ.get('SLURM_CPUS_PER_TASK')
+    default_workers = int(slurm_cpus) - 2 if slurm_cpus else min(mp.cpu_count() - 2, 12)
+    n_workers = max(1, int(os.environ.get('PROBLOG_WORKERS', default_workers)))
+    # Cap workers — ProbLog uses ~1.7GB per active worker with maxtasksperchild recycling
+    n_workers = min(n_workers, 180)
+
+    cache_dir = os.path.join(OUTPUT_DIR, 'cache')
+    os.makedirs(cache_dir, exist_ok=True)
+
+    precomputed = {llm: {} for llm in all_llm_indices}
+
+    for llm_name, idx in all_llm_indices.items():
+        cache_path = os.path.join(cache_dir, f'{llm_name}_precomputed.pkl')
+
+        # Check for cached results
+        if os.path.exists(cache_path):
+            print(f"  {llm_name}: loading from cache {cache_path}")
+            with open(cache_path, 'rb') as f:
+                precomputed[llm_name] = pickle.load(f)
+            print(f"  {llm_name}: {len(precomputed[llm_name])} cached entries loaded")
+            continue
+
+        t0 = time.time()
+        n_expected = len(score_configs) * len(all_ids_by_llm[llm_name])
+        print(f"  {llm_name}: ~{n_expected} work items (generator), {n_workers} workers...")
+
+        computed = 0
+        timed_out_idents = set()  # dynamically populated when workers timeout
+        gen = _work_item_generator(llm_name, idx, all_ids_by_llm[llm_name],
+                                   score_configs, timed_out_idents)
+
+        last_reported = [0]
+
+        def _progress(n_results):
+            nonlocal computed
+            if n_results // 10000 > last_reported[0]:
+                last_reported[0] = n_results // 10000
+                elapsed = time.time() - t0
+                print(f"    {llm_name}: {n_results} done ({elapsed:.0f}s)")
+
+        if n_workers <= 1:
+            for item in gen:
+                score_key, ident, facts, rules, query, da = item
+                sr = SemiringDampened(alpha=da) if da != 1.0 else None
+                prove_prob = execute_problog_direct(facts, rules, query, semiring=sr)
+                dep_facts = [{**f, 'probability': 1.0 if f['probability'] >= 0.5 else 0.0}
+                             for f in facts]
+                dep_prob = execute_problog_direct(dep_facts, rules, query, semiring=None)
+                if prove_prob is not None or dep_prob is not None:
+                    precomputed[llm_name][(score_key, ident)] = (prove_prob, dep_prob, len(facts))
+                    computed += 1
+                    _progress(computed)
+        else:
+            results = _run_parallel_with_timeout(
+                gen, n_workers, _progress, timed_out_idents,
+                batch_size=50, timeout_per_item=10
+            )
+            for r in results:
+                if r is not None:
+                    sk, ident, entry = r
+                    precomputed[llm_name][(sk, ident)] = entry
+                    computed += 1
+
+        elapsed = time.time() - t0
+        print(f"  {llm_name}: {computed} entries in {elapsed:.1f}s ({elapsed/60:.1f} min)")
+        if timed_out_idents:
+            print(f"  {llm_name}: {len(timed_out_idents)} samples auto-skipped after timeout: {sorted(timed_out_idents)}")
+
+        # Save to cache
+        with open(cache_path, 'wb') as f:
+            pickle.dump(precomputed[llm_name], f, protocol=pickle.HIGHEST_PROTOCOL)
+        print(f"  {llm_name}: cached to {cache_path}")
+
+    return precomputed
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# EVALUATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def evaluate_all(precomputed, all_llm_indices, all_labels, score_configs, threshold_configs):
+    """
+    Sweep all configs: score_config × threshold × LLM combo × vote type.
+    Fully vectorized: all thresholds processed simultaneously via numpy broadcasting.
+    Failed samples are counted as incorrect (not removed).
+    Returns list of result dicts.
+    """
+    llm_names = sorted(all_llm_indices.keys())
+
+    # Build LLM combos: singles + all ensemble sizes (2, 3, ..., N)
+    llm_combos = []
+    for llm in llm_names:
+        llm_combos.append(([llm], f"{llm}"))
+    for r in range(2, len(llm_names) + 1):
+        for combo in combinations(llm_names, r):
+            llm_combos.append((sorted(combo), "+".join(sorted(combo))))
+
+    all_sample_ids = sorted(all_labels.keys())
+    n = len(all_sample_ids)
+    n_thr = len(threshold_configs)
+    thr_names = [name for name, _ in threshold_configs]
+    print(f"  Universal sample set: {n} samples, {n_thr} thresholds")
+
+    labels_arr = np.array([all_labels[ident] for ident in all_sample_ids], dtype=bool)
+
+    all_results = []
+    t0 = time.time()
+    n_score = len(score_configs)
+
+    for si, score_key in enumerate(score_configs):
+        if si % 100 == 0:
+            print(f"  Evaluating score config {si}/{n_score} ({time.time()-t0:.1f}s)")
+
+        for llms, combo_name in llm_combos:
+            num_llms = len(llms)
+
+            # Build numpy arrays: [num_llms, n] with NaN for missing
+            prove_arr = np.full((num_llms, n), np.nan)
+            deprove_arr = np.full((num_llms, n), np.nan)
+            nfacts_arr = np.zeros((num_llms, n))
+
+            for j, llm in enumerate(llms):
+                for i, ident in enumerate(all_sample_ids):
+                    entry = precomputed[llm].get((score_key, ident))
+                    if entry is not None:
+                        prove_arr[j, i] = entry[0]
+                        deprove_arr[j, i] = entry[1]
+                        nfacts_arr[j, i] = entry[2]
+
+            valid_mask = ~np.isnan(prove_arr)  # [num_llms, n]
+            valid_count = valid_mask.sum(axis=0)  # [n]
+            any_valid = valid_count > 0  # [n]
+            vc = np.maximum(valid_count, 1)
+
+            # DePROVE predictions: deprove >= 0.5 (same for all thresholds)
+            deprove_preds = deprove_arr >= 0.5  # [num_llms, n]
+
+            is_ensemble = num_llms > 1
+            vote_types = ['soft', 'hard', 'conf_weighted', 'perf_weighted',
+                          'prove_weighted', 'prove_weighted_sq'] if is_ensemble else ['single']
+
+            if is_ensemble:
+                llm_dep_acc = np.zeros(num_llms)
+                for j in range(num_llms):
+                    vm = valid_mask[j]
+                    if vm.sum() > 0:
+                        llm_dep_acc[j] = ((deprove_preds[j] == labels_arr) & vm).sum() / n
+                    else:
+                        llm_dep_acc[j] = 0.5
+
+                # PROVE accuracy at reference threshold (t=0.35) per LLM
+                llm_prove_acc = np.zeros(num_llms)
+                for j in range(num_llms):
+                    vm = valid_mask[j]
+                    if vm.sum() > 0:
+                        prove_preds_ref = np.where(vm, prove_arr[j] >= 0.35, ~labels_arr)
+                        llm_prove_acc[j] = (prove_preds_ref == labels_arr).sum() / n
+                    else:
+                        llm_prove_acc[j] = 0.5
+
+            # DePROVE baseline: use best single-LLM DePROVE for ensembles
+            # (DePROVE outputs are binary 0/1, so soft-averaging creates an OR gate)
+            if is_ensemble:
+                per_llm_dep_correct = []
+                per_llm_dep_acc_vals = []
+                for j in range(num_llms):
+                    vm = valid_mask[j]
+                    dp = deprove_preds[j].copy()
+                    dp[~vm] = ~labels_arr[~vm]
+                    correct_j = (dp == labels_arr)
+                    per_llm_dep_correct.append(correct_j)
+                    per_llm_dep_acc_vals.append(correct_j.sum() / n)
+                best_j = int(np.argmax(per_llm_dep_acc_vals))
+                deprove_correct = per_llm_dep_correct[best_j]
+                dep_acc = per_llm_dep_acc_vals[best_j]
+            else:
+                dp = deprove_preds[0].copy()
+                dp[~valid_mask[0]] = ~labels_arr[~valid_mask[0]]
+                deprove_correct = (dp == labels_arr)
+                dep_acc = deprove_correct.sum() / n
+
+            # Vectorized thresholds: [n_thr, num_llms, n]
+            all_thresholds = compute_thresholds_vectorized(nfacts_arr, threshold_configs)
+            # prove_arr: [num_llms, n] -> broadcast with [n_thr, num_llms, n]
+            prove_preds_all = prove_arr[None, :, :] >= all_thresholds  # [n_thr, num_llms, n]
+
+            # For soft/weighted votes, compute avg nfacts thresholds: [n_thr, n]
+            nf_safe = np.where(valid_mask, nfacts_arr, 0.0)
+            avg_nf = nf_safe.sum(axis=0) / vc  # [n]
+            avg_thresholds = compute_thresholds_vectorized(avg_nf, threshold_configs)  # [n_thr, n]
+
+            # Pre-compute shared quantities for soft/weighted votes
+            pp_safe = np.where(valid_mask, prove_arr, 0.0)
+            avg_pp = pp_safe.sum(axis=0) / vc  # [n]
+
+            for vote_type in vote_types:
+                # deprove_correct and dep_acc are already computed above
+                # (best single-LLM for ensembles, single LLM for non-ensemble)
+
+                if vote_type == 'single':
+                    # [n_thr, n]
+                    prove_pred = prove_preds_all[:, 0, :].copy()
+                    prove_pred[:, ~valid_mask[0]] = ~labels_arr[~valid_mask[0]]
+                elif vote_type == 'soft':
+                    prove_pred = avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+                elif vote_type == 'hard':
+                    pp_votes = (prove_preds_all & valid_mask[None, :, :]).sum(axis=1).astype(float)  # [n_thr, n]
+                    prove_pred = pp_votes > valid_count[None, :] / 2.0
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+                elif vote_type == 'conf_weighted':
+                    weights = np.abs(prove_arr - 0.5) + 1e-6
+                    weights = np.where(valid_mask, weights, 0.0)
+                    w_sum = np.maximum(weights.sum(axis=0), 1e-12)
+                    w_avg_pp = (weights * pp_safe).sum(axis=0) / w_sum  # [n]
+                    prove_pred = w_avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+                elif vote_type == 'perf_weighted':
+                    weights = llm_dep_acc[:, None] * valid_mask.astype(float)
+                    w_sum = np.maximum(weights.sum(axis=0), 1e-12)
+                    w_avg_pp = (weights * pp_safe).sum(axis=0) / w_sum  # [n]
+                    prove_pred = w_avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+                elif vote_type == 'prove_weighted':
+                    weights = llm_prove_acc[:, None] * valid_mask.astype(float)
+                    w_sum = np.maximum(weights.sum(axis=0), 1e-12)
+                    w_avg_pp = (weights * pp_safe).sum(axis=0) / w_sum  # [n]
+                    prove_pred = w_avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+                elif vote_type == 'prove_weighted_sq':
+                    weights = (llm_prove_acc ** 2)[:, None] * valid_mask.astype(float)
+                    w_sum = np.maximum(weights.sum(axis=0), 1e-12)
+                    w_avg_pp = (weights * pp_safe).sum(axis=0) / w_sum  # [n]
+                    prove_pred = w_avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+                    prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+
+                # Vectorized accuracy and McNemar across all thresholds at once
+                prove_correct = (prove_pred == labels_arr[None, :])  # [n_thr, n]
+                prove_acc_arr = prove_correct.sum(axis=1) / n  # [n_thr]
+
+                # Vectorized McNemar: pw = prove_correct & ~deprove_correct, dw = ~prove_correct & deprove_correct
+                dep_correct_2d = deprove_correct[None, :]  # [1, n]
+                pw_arr = (prove_correct & ~dep_correct_2d).sum(axis=1)  # [n_thr]
+                dw_arr = (~prove_correct & dep_correct_2d).sum(axis=1)  # [n_thr]
+                pd_sum = pw_arr + dw_arr
+                chi2_arr = np.where(pd_sum > 0, (pw_arr - dw_arr) ** 2 / pd_sum, 0.0)
+                delta_arr = prove_acc_arr - dep_acc
+                sig_arr = (chi2_arr >= 3.84) & (delta_arr > 0)
+
+                for ti in range(n_thr):
+                    all_results.append({
+                        'score_key': score_key,
+                        'combo': combo_name,
+                        'vote': vote_type,
+                        'threshold': thr_names[ti],
+                        'n': int(n),
+                        'prove_acc': float(round(float(prove_acc_arr[ti]) * 100, 2)),
+                        'deprove_acc': float(round(dep_acc * 100, 2)),
+                        'delta': float(round(float(delta_arr[ti]) * 100, 2)),
+                        'chi2': float(round(float(chi2_arr[ti]), 2)),
+                        'significant': bool(sig_arr[ti]),
+                    })
+
+    elapsed = time.time() - t0
+    print(f"Evaluation: {len(all_results)} configs in {elapsed:.1f}s")
+    return all_results
+
+
+def evaluate_perlm_configs(precomputed, all_llm_indices, all_labels,
+                           score_configs, threshold_configs, top_k=10,
+                           max_results=10000):
+    """
+    Per-LLM config optimization: each LLM uses its own best score config,
+    but all share the same threshold. Vectorized with numpy.
+    """
+    llm_names = sorted(all_llm_indices.keys())
+    all_sample_ids = sorted(all_labels.keys())
+    n = len(all_sample_ids)
+    n_thr = len(threshold_configs)
+    thr_names = [name for name, _ in threshold_configs]
+    labels_arr = np.array([all_labels[ident] for ident in all_sample_ids], dtype=bool)
+
+    # Step 1: Find top-K score configs per LLM (vectorized)
+    print(f"  Finding top-{top_k} score configs per LLM...")
+    topk_per_llm = {}
+
+    for llm in llm_names:
+        config_accs = []
+        for score_key in score_configs:
+            prove_probs = np.full(n, np.nan)
+            for i, ident in enumerate(all_sample_ids):
+                entry = precomputed[llm].get((score_key, ident))
+                if entry is not None:
+                    prove_probs[i] = entry[0]
+            valid = ~np.isnan(prove_probs)
+            preds = np.where(valid, prove_probs >= 0.3, ~labels_arr)
+            correct = (preds == labels_arr).sum()
+            config_accs.append((correct / n, score_key))
+
+        config_accs.sort(reverse=True)
+        topk_per_llm[llm] = [sk for _, sk in config_accs[:top_k]]
+        print(f"    {llm}: top-{top_k} configs (best single acc={100*config_accs[0][0]:.2f}%)")
+        for acc, sk in config_accs[:3]:
+            print(f"      {100*acc:.2f}% | {sk}")
+
+    from itertools import product
+
+    llm_combos = []
+    for r in range(2, len(llm_names) + 1):
+        for combo in combinations(llm_names, r):
+            llm_combos.append((sorted(combo), "+".join(sorted(combo))))
+
+    # Use a bounded heap to keep only top results (avoids storing millions of result dicts)
+    top_heap = []  # min-heap of (prove_acc, counter, result_dict)
+    heap_counter = 0
+    min_acc_in_heap = -float('inf')
+    total_evaluated = 0
+    t0 = time.time()
+
+    for llms, combo_name in llm_combos:
+        effective_k = top_k  # Full top_k for ALL ensemble sizes
+        per_llm_configs = [topk_per_llm[llm][:effective_k] for llm in llms]
+        n_combos = 1
+        for c in per_llm_configs:
+            n_combos *= len(c)
+        print(f"  {combo_name}: {n_combos} score combos × {len(threshold_configs)} thresholds (top_k={effective_k})")
+        num_llms = len(llms)
+
+        for score_combo in product(*per_llm_configs):
+            score_combo_name = "perlm|" + "|".join(
+                f"{llm}:{sk.split('|')[0]}" for llm, sk in zip(llms, score_combo)
+            )
+
+            # Build numpy arrays
+            prove_arr = np.full((num_llms, n), np.nan)
+            deprove_arr = np.full((num_llms, n), np.nan)
+            nfacts_arr = np.zeros((num_llms, n))
+
+            for j, llm in enumerate(llms):
+                sk = score_combo[j]
+                for i, ident in enumerate(all_sample_ids):
+                    entry = precomputed[llm].get((sk, ident))
+                    if entry is not None:
+                        prove_arr[j, i] = entry[0]
+                        deprove_arr[j, i] = entry[1]
+                        nfacts_arr[j, i] = entry[2]
+
+            valid_mask = ~np.isnan(prove_arr)
+            valid_count = valid_mask.sum(axis=0)
+            any_valid = valid_count > 0
+            vc = np.maximum(valid_count, 1)
+
+            # DePROVE: per-LLM accuracies (deterministic output is binary, so no ensemble averaging)
+            per_llm_deprove_acc = {}
+            for j, llm in enumerate(llms):
+                vm = valid_mask[j]
+                dep_pred_j = deprove_arr[j] >= 0.5
+                dep_pred_j[~vm] = ~labels_arr[~vm]
+                per_llm_deprove_acc[llm] = float((dep_pred_j == labels_arr).sum()) / n
+
+            # For McNemar test, use the best single-LLM DePROVE as baseline
+            best_dep_llm = max(per_llm_deprove_acc, key=per_llm_deprove_acc.get)
+            dep_pred_best = deprove_arr[llms.index(best_dep_llm)] >= 0.5
+            vm_best = valid_mask[llms.index(best_dep_llm)]
+            dep_pred_best[~vm_best] = ~labels_arr[~vm_best]
+            deprove_correct = (dep_pred_best == labels_arr)
+            dep_acc = per_llm_deprove_acc[best_dep_llm]
+
+            # Vectorized across all thresholds at once
+            pp_safe = np.where(valid_mask, prove_arr, 0.0)
+            avg_pp = pp_safe.sum(axis=0) / vc  # [n]
+            nf_safe = np.where(valid_mask, nfacts_arr, 0.0)
+            avg_nf = nf_safe.sum(axis=0) / vc  # [n]
+            avg_thresholds = compute_thresholds_vectorized(avg_nf, threshold_configs)  # [n_thr, n]
+
+            prove_pred = avg_pp[None, :] >= avg_thresholds  # [n_thr, n]
+            prove_pred[:, ~any_valid] = ~labels_arr[~any_valid]
+
+            prove_correct = (prove_pred == labels_arr[None, :])  # [n_thr, n]
+            prove_acc_arr = prove_correct.sum(axis=1) / n  # [n_thr]
+
+            dep_correct_2d = deprove_correct[None, :]  # [1, n]
+            pw_arr = (prove_correct & ~dep_correct_2d).sum(axis=1)
+            dw_arr = (~prove_correct & dep_correct_2d).sum(axis=1)
+            pd_sum = pw_arr + dw_arr
+            chi2_arr = np.where(pd_sum > 0, (pw_arr - dw_arr) ** 2 / pd_sum, 0.0)
+            delta_arr = prove_acc_arr - dep_acc
+            sig_arr = (chi2_arr >= 3.84) & (delta_arr > 0)
+
+            # Full per-LLM score config mapping
+            score_detail = {llm: sk for llm, sk in zip(llms, score_combo)}
+
+            # Per-LLM DePROVE accuracies rounded
+            deprove_per_llm = {llm: round(acc * 100, 2) for llm, acc in per_llm_deprove_acc.items()}
+
+            # Instead of saving ALL n_thr results, find top-5 thresholds for this score combo
+            best_ti_indices = np.argsort(prove_acc_arr)[-5:][::-1]
+            total_evaluated += n_thr  # Count all thresholds as evaluated
+
+            for ti in best_ti_indices:
+                acc_pct = float(round(float(prove_acc_arr[ti]) * 100, 2))
+
+                if len(top_heap) < max_results or acc_pct > min_acc_in_heap:
+                    result = {
+                        'score_key': score_combo_name,
+                        'score_detail': score_detail,
+                        'combo': combo_name,
+                        'vote': 'perlm_soft',
+                        'threshold': thr_names[ti],
+                        'n': int(n),
+                        'prove_acc': acc_pct,
+                        'deprove_acc': float(round(dep_acc * 100, 2)),
+                        'deprove_per_llm': deprove_per_llm,
+                        'delta': float(round(float(delta_arr[ti]) * 100, 2)),
+                        'chi2': float(round(float(chi2_arr[ti]), 2)),
+                        'significant': bool(sig_arr[ti]),
+                    }
+                    if len(top_heap) < max_results:
+                        heapq.heappush(top_heap, (acc_pct, heap_counter, result))
+                        heap_counter += 1
+                        if len(top_heap) == max_results:
+                            min_acc_in_heap = top_heap[0][0]
+                    else:
+                        heapq.heapreplace(top_heap, (acc_pct, heap_counter, result))
+                        heap_counter += 1
+                        min_acc_in_heap = top_heap[0][0]
+
+    all_results = [item[2] for item in sorted(top_heap, key=lambda x: -x[0])]
+    elapsed = time.time() - t0
+    print(f"  Per-LLM evaluation: {total_evaluated} threshold evals across all combos, top {len(all_results)} saved, in {elapsed:.1f}s")
+
+    print(f"\n  Top 10 per-LLM optimized configs:")
+    print(f"  {'PROVE%':>7} {'DeP%':>7} {'Δ':>7} {'χ²':>6} {'Sig':>4} {'N':>5} | Config")
+    for r in all_results[:10]:
+        s = '*' if r['significant'] else ''
+        print(f"  {r['prove_acc']:>7.2f} {r['deprove_acc']:>7.2f} {r['delta']:>+7.2f} {r['chi2']:>6.1f} {s:>4} {r['n']:>5} | {r['combo']}|{r['vote']}|{r['threshold']}|{r['score_key']}")
+
+    return all_results
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# REPORTING
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def print_summary(all_results):
+    sig_results = [r for r in all_results if r['significant']]
+    print(f"\n{'='*100}")
+    print(f"TOTAL: {len(all_results)} configs evaluated, {len(sig_results)} significant (p<0.05, PROVE > DePROVE)")
+    print(f"{'='*100}")
+
+    # Top 30 overall by PROVE accuracy
+    sorted_all = sorted(all_results, key=lambda r: (-r['prove_acc'], -r['delta']))
+    print(f"\n--- TOP 30 OVERALL (by PROVE accuracy) ---")
+    print(f"{'PROVE%':>7} {'DeP%':>7} {'Δ':>7} {'χ²':>6} {'Sig':>4} {'N':>5} | Config")
+    for r in sorted_all[:30]:
+        s = '*' if r['significant'] else ''
+        config = f"{r['combo']}|{r['vote']}|{r['threshold']}|{r['score_key']}"
+        print(f"{r['prove_acc']:>7.2f} {r['deprove_acc']:>7.2f} {r['delta']:>+7.2f} {r['chi2']:>6.1f} {s:>4} {r['n']:>5} | {config}")
+
+    # Top 10 significant by delta
+    sorted_sig = sorted(sig_results, key=lambda r: -r['delta'])
+    if sorted_sig:
+        print(f"\n--- TOP 10 SIGNIFICANT (by delta PROVE - DePROVE) ---")
+        print(f"{'PROVE%':>7} {'DeP%':>7} {'Δ':>7} {'χ²':>6} {'N':>5} | Config")
+        for r in sorted_sig[:10]:
+            config = f"{r['combo']}|{r['vote']}|{r['threshold']}|{r['score_key']}"
+            print(f"{r['prove_acc']:>7.2f} {r['deprove_acc']:>7.2f} {r['delta']:>+7.2f} {r['chi2']:>6.1f} {r['n']:>5} | {config}")
+
+    # Best per LLM combo
+    combos = sorted(set(r['combo'] for r in all_results))
+    print(f"\n--- BEST PER LLM COMBO ---")
+    print(f"{'Combo':<30} {'PROVE%':>7} {'DeP%':>7} {'Δ':>7} {'χ²':>6} {'Sig':>4} | Config")
+    for combo in combos:
+        combo_results = [r for r in all_results if r['combo'] == combo]
+        best = max(combo_results, key=lambda r: r['prove_acc'])
+        s = '*' if best['significant'] else ''
+        config = f"{best['vote']}|{best['threshold']}|{best['score_key']}"
+        print(f"{combo:<30} {best['prove_acc']:>7.2f} {best['deprove_acc']:>7.2f} {best['delta']:>+7.2f} {best['chi2']:>6.1f} {s:>4} | {config}")
+
+    # Factor analysis: which dimension matters most?
+    print(f"\n--- FACTOR ANALYSIS (avg PROVE acc by factor level) ---")
+
+    # By score type (extract from score_key)
+    print("\nVQA Score Type:")
+    score_accs = defaultdict(list)
+    for r in all_results:
+        # Extract the score part (before first |)
+        score_part = r['score_key'].split('|')[0]
+        score_accs[score_part].append(r['prove_acc'])
+    for score, accs in sorted(score_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {score:<30} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+    # By entity prob
+    print("\nEntity Probability:")
+    ep_accs = defaultdict(list)
+    for r in all_results:
+        for part in r['score_key'].split('|'):
+            if part.startswith('ep='):
+                ep_accs[part].append(r['prove_acc'])
+    for ep, accs in sorted(ep_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {ep:<20} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+    # By dampening
+    print("\nDampening Alpha:")
+    da_accs = defaultdict(list)
+    for r in all_results:
+        for part in r['score_key'].split('|'):
+            if part.startswith('da='):
+                da_accs[part].append(r['prove_acc'])
+    for da, accs in sorted(da_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {da:<20} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+    # By agreement mode
+    print("\nVQA Agreement:")
+    ag_accs = defaultdict(list)
+    for r in all_results:
+        for part in r['score_key'].split('|'):
+            if part.startswith('ag='):
+                ag_accs[part].append(r['prove_acc'])
+    for ag, accs in sorted(ag_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {ag:<20} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+    # By threshold type (fixed vs dynamic)
+    print("\nThreshold Type:")
+    thr_accs = defaultdict(list)
+    for r in all_results:
+        thr = r['threshold']
+        thr_type = 'fixed' if thr.startswith('t=') else 'log' if thr.startswith('log(') else 'linear' if thr.startswith('lin(') else 'binned'
+        thr_accs[thr_type].append(r['prove_acc'])
+    for tt, accs in sorted(thr_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {tt:<20} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+    # By vote type
+    print("\nVote Type:")
+    vote_accs = defaultdict(list)
+    for r in all_results:
+        vote_accs[r['vote']].append(r['prove_acc'])
+    for vt, accs in sorted(vote_accs.items(), key=lambda x: -sum(x[1])/len(x[1])):
+        print(f"  {vt:<20} avg={sum(accs)/len(accs):.2f}% (n={len(accs)})")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def main():
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    start_time = time.time()
+
+    # Load all LLM results
+    all_llm_indices = {}
+    all_ids_by_llm = {}
+    all_labels = {}  # universal label lookup: ident → label (includes failed samples)
+    for llm_name, path in LLM_RESULT_FILES.items():
+        full_path = os.path.join(_PROJECT_ROOT, path)
+        if not os.path.exists(full_path):
+            print(f"Skipping {llm_name}: {path} not found")
+            continue
+        with open(full_path) as f:
+            data = json.load(f)
+        idx = build_llm_index(data)
+        all_llm_indices[llm_name] = idx
+        all_ids_by_llm[llm_name] = sorted(idx.keys())
+        # Build universal label set from VALID samples only (failed excluded from sweep)
+        for ident, sample in idx.items():
+            label = sample.get('label')
+            if label is not None:
+                all_labels[ident] = label
+        n_failed = sum(1 for s in data if s.get('identifier') and not s.get('success', False) and s.get('label') is not None)
+        print(f"Loaded {llm_name}: {len(idx)} valid samples, {n_failed} failed (excluded from sweep)")
+
+    # Build score configs
+    score_configs = make_score_configs()
+    print(f"\nScore configs: {len(score_configs)}")
+
+    # Build threshold configs
+    threshold_configs = make_threshold_configs()
+    print(f"Threshold configs: {len(threshold_configs)}")
+
+    # Precompute ProbLog results
+    print(f"\n{'='*80}")
+    print("PRECOMPUTING ProbLog results...")
+    print(f"{'='*80}")
+    precomputed = precompute_all(all_llm_indices, all_ids_by_llm, score_configs)
+    precompute_time = time.time() - start_time
+    print(f"\nPrecomputation done in {precompute_time:.1f}s ({precompute_time/60:.1f} min)")
+
+    # Evaluate all configs
+    print(f"\n{'='*80}")
+    print("EVALUATING all configs...")
+    print(f"{'='*80}")
+    all_results = evaluate_all(precomputed, all_llm_indices, all_labels, score_configs, threshold_configs)
+
+    # Print summary
+    print_summary(all_results)
+
+    # Per-LLM config optimization (shared threshold, different score configs)
+    print(f"\n{'='*80}")
+    print("PER-LLM CONFIG OPTIMIZATION (shared threshold, per-LLM score config)")
+    print(f"{'='*80}")
+    perlm_results = evaluate_perlm_configs(precomputed, all_llm_indices, all_labels,
+                                            score_configs, threshold_configs)
+    all_results.extend(perlm_results)
+
+    # Print summary
+    print_summary(all_results)
+
+    # Save results
+    output_path = os.path.join(OUTPUT_DIR, 'results.json')
+    with open(output_path, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nResults saved to {output_path}")
+
+    total_time = time.time() - start_time
+    print(f"\n{'='*80}")
+    print(f"Total time: {total_time:.1f}s ({total_time/60:.1f} min)")
+    print(f"{'='*80}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pipeline/unified_agent.py
+++ b/src/pipeline/unified_agent.py
@@ -62,6 +62,10 @@ class EvidenceCollection:
     # Turn-by-turn action history: [{"thought": "...", "action": "...", "result": "..."}]
     action_history: List[Dict[str, str]] = field(default_factory=list)
 
+    # Rich score dicts from all verifiers (replaces rescore_with_qwen)
+    attribute_scores: List[Dict[str, Any]] = field(default_factory=list)
+    relationship_scores: List[Dict[str, Any]] = field(default_factory=list)
+
     def add_attribute(self, entity_id: str, attribute: str, probability: float):
         self.attributes.append((entity_id, attribute, probability))
 
@@ -90,9 +94,10 @@ class UnifiedAgent:
     # Minimum verify actions before "done" is accepted
     MIN_VERIFY_ACTIONS = 1
 
-    def __init__(self, max_iterations: int = 15):
+    def __init__(self, max_iterations: int = 15, extra_verifiers: Dict[str, Any] = None):
         self.max_iterations = max_iterations
         self.model_manager = ModelManager()
+        self.extra_verifiers = extra_verifiers or {}
         # Detect Nova models for prompt adjustments
         model_id = os.environ.get("LLAMA33_MODEL_ID", "")
         self.is_nova = "nova" in model_id.lower()
@@ -355,10 +360,32 @@ What is your next action? Output JSON only:"""
                 verification=action.verification
             )
 
-            # Store evidence for probability computation
+            # Store evidence tuple for ProbLog fact building
             evidence.add_attribute(action.entity_id, action.attribute, probability)
 
-            # Record action with result
+            # Build rich score dict with all verifier scores
+            score_dict = {
+                "entity_id": action.entity_id,
+                "value": action.attribute,
+                "blip_score": probability,
+                "image_id": entity.image_id,
+                "bbox": entity.bbox,
+                "object_class": entity.object_class,
+            }
+            for name, verifier in self.extra_verifiers.items():
+                try:
+                    v_score, v_resp = verifier.verify_attribute(
+                        image_path, entity.bbox, entity.object_class,
+                        action.attribute, use_logits=True
+                    )
+                    score_dict[f"{name}_score"] = v_score
+                    score_dict[f"{name}_response"] = v_resp
+                except Exception as ve:
+                    score_dict[f"{name}_score"] = None
+                    score_dict[f"{name}_response"] = f"ERROR: {ve}"
+            evidence.attribute_scores.append(score_dict)
+
+            # Record action with result (agent sees BLIP score)
             evidence.add_action(action.thought, action_str, f"p={probability:.3f}")
             print(f"  [Verify Attribute] {action.entity_id}.{action.attribute}")
             print(f"    verification: \"{action.verification}\"")
@@ -416,10 +443,36 @@ What is your next action? Output JSON only:"""
                 verification=action.verification
             )
 
-            # Store evidence for probability computation
+            # Store evidence tuple for ProbLog fact building
             evidence.add_relationship(action.subject_id, action.object_id, action.relation, probability)
 
-            # Record action with result
+            # Build rich score dict with all verifier scores
+            score_dict = {
+                "subject_id": action.subject_id,
+                "object_id": action.object_id,
+                "relation": action.relation,
+                "blip_score": probability,
+                "image_id": subject.image_id,
+                "bbox1": subject.bbox,
+                "bbox2": obj.bbox,
+                "obj1_class": subject.object_class,
+                "obj2_class": obj.object_class,
+            }
+            for name, verifier in self.extra_verifiers.items():
+                try:
+                    v_score, v_resp = verifier.verify_relationship(
+                        image_path, subject.bbox, obj.bbox,
+                        subject.object_class, obj.object_class,
+                        action.relation, use_logits=True
+                    )
+                    score_dict[f"{name}_score"] = v_score
+                    score_dict[f"{name}_response"] = v_resp
+                except Exception as ve:
+                    score_dict[f"{name}_score"] = None
+                    score_dict[f"{name}_response"] = f"ERROR: {ve}"
+            evidence.relationship_scores.append(score_dict)
+
+            # Record action with result (agent sees BLIP score)
             evidence.add_action(action.thought, action_str, f"p={probability:.3f}")
             print(f"  [Verify Relationship] {action.subject_id} {action.relation} {action.object_id}")
             print(f"    verification: \"{action.verification}\"")

--- a/src/vision/qwen_verifier.py
+++ b/src/vision/qwen_verifier.py
@@ -1,6 +1,6 @@
 """
 Qwen 2.5-VL-7B verifier for PROVE pipeline.
-Uses Yes/No or True/False prompting for binary verification with probability extraction.
+Uses True/False prompting for binary verification with probability extraction.
 """
 
 import torch
@@ -14,7 +14,7 @@ class QwenVerifier:
     """
     Qwen 2.5-VL-7B based verifier for attribute and relationship verification.
 
-    Uses prompted Yes/No or True/False responses with logit-based probability extraction.
+    Uses prompted True/False responses with logit-based probability extraction.
     """
 
     PADDING_RATIO = 0.15  # 15% padding on each side
@@ -22,7 +22,6 @@ class QwenVerifier:
     def __init__(
         self,
         qwen_vl: QwenVL = None,
-        prompt_style: str = "yes_no",
         device: str = "auto"
     ):
         """
@@ -30,10 +29,8 @@ class QwenVerifier:
 
         Args:
             qwen_vl: Existing QwenVL instance to reuse (avoids redundant loading)
-            prompt_style: "yes_no" or "true_false"
             device: Device to use
         """
-        self.prompt_style = prompt_style
         self.device = device
 
         # Reuse existing QwenVL instance or create new one
@@ -81,33 +78,26 @@ class QwenVerifier:
 
     def _get_vlm_probability(self, image: Image.Image, statement: str) -> Tuple[float, str]:
         """
-        Get probability from VLM response.
+        Get probability from VLM response via text parsing (fallback).
 
         Returns:
             Tuple of (probability, raw_response)
         """
         qwen = self._get_qwen()
 
-        if self.prompt_style == "true_false":
-            prompt = f'Determine if the following statement about this image is true or false.\n\nStatement: "{statement}"\n\nAnswer with ONLY "True" or "False".'
-            pos_tokens = ["true", "correct", "yes"]
-            neg_tokens = ["false", "incorrect", "no"]
-        else:  # yes_no
-            prompt = f'Is the following statement about this image correct?\n\nStatement: "{statement}"\n\nAnswer with ONLY "Yes" or "No".'
-            pos_tokens = ["yes", "correct", "true"]
-            neg_tokens = ["no", "incorrect", "false"]
+        prompt = f'Determine if the following statement about this image is true or false.\n\nStatement: "{statement}"\n\nAnswer with ONLY "True" or "False".'
+        pos_tokens = ["true", "correct", "yes"]
+        neg_tokens = ["false", "incorrect", "no"]
 
         try:
             response = qwen.run_inference(image, prompt)
             response_lower = response.lower().strip()
 
-            # Check for positive response
             if any(pos in response_lower for pos in pos_tokens):
                 return 0.9, response
             elif any(neg in response_lower for neg in neg_tokens):
                 return 0.1, response
             else:
-                # Ambiguous response
                 return 0.5, response
 
         except Exception as e:
@@ -118,14 +108,12 @@ class QwenVerifier:
         """
         Get probability from VLM using token logits for better calibration.
 
-        This method tries to extract actual probabilities from the model's logits.
+        This method extracts actual probabilities from the model's logits
+        over True/False tokens.
         """
         qwen = self._get_qwen()
 
-        if self.prompt_style == "true_false":
-            prompt = f'Determine if the following statement about this image is true or false.\n\nStatement: "{statement}"\n\nAnswer with ONLY "True" or "False".'
-        else:  # yes_no
-            prompt = f'Is the following statement about this image correct?\n\nStatement: "{statement}"\n\nAnswer with ONLY "Yes" or "No".'
+        prompt = f'Determine if the following statement about this image is true or false.\n\nStatement: "{statement}"\n\nAnswer with ONLY "True" or "False".'
 
         try:
             # Load image if needed
@@ -169,13 +157,9 @@ class QwenVerifier:
                 )
                 logits = outputs.logits[:, -1, :]  # Last position logits
 
-                # Get token IDs for Yes/No or True/False
-                if self.prompt_style == "true_false":
-                    pos_tokens = ["True", "true", "TRUE"]
-                    neg_tokens = ["False", "false", "FALSE"]
-                else:
-                    pos_tokens = ["Yes", "yes", "YES"]
-                    neg_tokens = ["No", "no", "NO"]
+                # Get token IDs for True/False
+                pos_tokens = ["True", "true", "TRUE"]
+                neg_tokens = ["False", "false", "FALSE"]
 
                 pos_ids = []
                 neg_ids = []


### PR DESCRIPTION
… tools

- Add Qwen as extra verifier alongside BLIP in unified_agent, storing rich score dicts with all verifier outputs per attribute/relationship
- Simplify QwenVerifier to True/False prompting only (remove yes_no style)
- Add src/eval/ with run_eval.py (multi-LLM eval pipeline with post-hoc ProbLog re-evaluation), analyze_subsets.py (subset analysis from stored predictions), and shared problog_utils.py
- Extract scoring configs into configs.json (v5_perlm, shared_best)
- Store posthoc_prove_pred/deprove_pred in results so analyze_subsets needs no ProbLog dependency
- Fix .gitignore to only ignore top-level eval/ (results), not src/eval/